### PR TITLE
Escape password in URL to support special chars.

### DIFF
--- a/cloudant.js
+++ b/cloudant.js
@@ -26,7 +26,7 @@ function reconfigure(config) {
 
   // Configure for Cloudant, either authenticated or anonymous.
   if (config.account && config.password)
-    config.url = 'https://' + username + ':' + config.password + '@' + config.account + '.cloudant.com';
+    config.url = 'https://' + username + ':' + escape(config.password) + '@' + config.account + '.cloudant.com';
   else if (config.account)
     config.url = 'https://' + config.account + '.cloudant.com';
 


### PR DESCRIPTION
Special chars, such as #, in a Cloudant password were resulting in a generic authentication error when trying to connect to Cloudant during the configuration process. Escaping the password in config.url variable fixed the issue.