### PR TITLE
Added support for _security Cloudant endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,14 +233,18 @@ Output:
 Next, set access roles for this API key:
 
 ~~~ js
-  // Set read-only access for this key.
-  var db = "my_database"
-  cloudant.set_permissions({database:db, username:api.key, roles:['_reader']}, function(er, result) {
+
+  
+  // Set the security for three users.
+  var db = "my_database",
+    roles = [ '_reader', '_writer' ];
+
+  cloudant.set_security( db, 'isdaingialkyciffestontsk', roles, function(er, result) {
     if (er)
       throw er
 
-    console.log('%s now has read-only access to %s', api.key, db)
-  })
+    console.log(result);
+  });
 })
 ~~~
 

--- a/README.md
+++ b/README.md
@@ -237,16 +237,59 @@ Next, set access roles for this API key:
   
   // Set the security for three users.
   var db = "my_database",
-    roles = [ '_reader', '_writer' ];
+    security = { 
+                cloudant: {
+                   nobody: []
+                   fred : [ '_reader', '_writer', '_admin', '_replicator' ],
+                   isdaingialkyciffestontsk: [ '_reader', '_writer' ]
+                 }
+               }; 
 
-  cloudant.set_security( db, 'isdaingialkyciffestontsk', roles, function(er, result) {
+  cloudant.set_security( database, security, function(er, result) {
     if (er)
       throw er
 
     console.log(result);
   });
-})
+  
 ~~~
+
+or read the security settings for a database
+
+~~~ js
+
+ var db = "my_database",
+
+ cloudant.view_security( database, function(er, result) {
+   if (er)
+     throw er
+
+   console.log(result);
+ });
+
+~~~
+
+Output:
+
+```
+{
+  "cloudant": {
+    "nobody": [],
+    "fred": [
+      "_reader",
+      "_writer",
+      "_admin",
+      "_replicator"
+    ],
+    "isdaingialkyciffestontsk": [
+      "_reader",
+      "_writer"
+    ]
+  }
+}
+```
+
+See the Cloudant API for full details](https://docs.cloudant.com/api.html#authorization)
 
 ### Use an API Key
 

--- a/cloudant.js
+++ b/cloudant.js
@@ -141,6 +141,7 @@ function set_security(db, security, callback) {
 
 
 function set_permissions(opts, callback) {
+  console.warn("DEPRECATED: set_permissions has been replaced by set_security");
   var nano = this;
 
   if (!nano.config.account)


### PR DESCRIPTION
Fixes #6 

The current release uses the deprecated APIs for assigning permissions to users. I've kept these calls the same, but added a deprecation warning and added two new function calls:

* cloudant.view_security(db, callback)
* cloudant.set_security(db, security, callback)

I've followed the same verbs as the other API calls and haven't attempted to hide what the API is doing e.g. I haven't tried to abstract e.g. cloudant.set_role(db, user, roles), for instance.

The functions are wangled into Nano using the same fix_request as the other Cloudant-specific functions.

