### PR TITLE
Removes a trailing `/` from a manually specified URL.

### DIFF
--- a/lib/reconfigure.js
+++ b/lib/reconfigure.js
@@ -12,6 +12,7 @@ var url = require('url');
 module.exports = function(config) {
   config = JSON.parse(JSON.stringify(config)); //clone
 
+  var outUrl; 
   // if a full URL is passed in
   if (config.url) {
     
@@ -36,7 +37,7 @@ module.exports = function(config) {
       config.url = url.format(parsed);
     }
     
-    return config.url;
+    outUrl = config.url;
   
   } else {
     // An account can be just the username, or the full cloudant URL.
@@ -51,17 +52,28 @@ module.exports = function(config) {
     var password = credentials.password;
 
     // Configure for Cloudant, either authenticated or anonymous.
-    if (config.account && password)
+    if (config.account && password) {
       config.url = 'https://' + encodeURIComponent(username) + ':' +
                     encodeURIComponent(password) + '@' +
                     encodeURIComponent(config.account) + '.cloudant.com';
-    else if (config.account)
+    }
+    else if (config.account) {
       config.url = 'https://' + encodeURIComponent(config.account) +
                    '.cloudant.com';
+    }
+    
+    outUrl = config.url;
   }
-
-
-  return config.url;
+  
+  // We trim out the trailing `/` because when the URL tracks down to `nano` we have to 
+  // worry that the trailing `/` doubles up depending on how URLs are built, this creates 
+  // "Database does not exist." errors. 
+  // Issue: cloudant/nodejs-cloudant#129
+  if (outUrl.slice(-1) == '/') {
+    outUrl = outUrl.slice(0, -1);
+  }
+  
+  return outUrl;
 };
 
 module.exports.getCredentials = getCredentials;

--- a/tests/reconfigure.js
+++ b/tests/reconfigure.js
@@ -85,4 +85,13 @@ describe('Reconfigure', function() {
     done();
   });
   
+  // Issue cloudant/nodejs-cloudant#129
+  it('fixes an HTTP Cloudant URL with a trailing / - removing the /', function(done) {
+    var credentials = { url: "http://mykey:mypassword@mydomain.cloudant.com/" };
+    var url = reconfigure(credentials);
+    url.should.be.a.String;
+    url.should.equal("https://mykey:mypassword@mydomain.cloudant.com");
+    done();
+  });
+  
 });

--- a/tests/reconfigure.js
+++ b/tests/reconfigure.js
@@ -86,8 +86,8 @@ describe('Reconfigure', function() {
   });
   
   // Issue cloudant/nodejs-cloudant#129
-  it('fixes an HTTP Cloudant URL with a trailing / - removing the /', function(done) {
-    var credentials = { url: "http://mykey:mypassword@mydomain.cloudant.com/" };
+  it('fixes a Cloudant URL with a trailing / - removing the /', function(done) {
+    var credentials = { url: "https://mykey:mypassword@mydomain.cloudant.com/" };
     var url = reconfigure(credentials);
     url.should.be.a.String;
     url.should.equal("https://mykey:mypassword@mydomain.cloudant.com");


### PR DESCRIPTION
Fixes #129.

Tests:
`npm test`
<img width="554" alt="screen shot 2016-05-04 at 12 16 45" src="https://cloud.githubusercontent.com/assets/302365/15020915/1f61a430-11f2-11e6-9376-9a77a7a89cbe.png">

I noticed some of the other tests do fail, though. 