### PR TITLE
Plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ This is the official Cloudant library for Node.js.
   * [Callback Signature](#callback-signature)
   * [Password Authentication](#password-authentication)
   * [Cloudant Local](#cloudant-local)
+  * [Request Plugins](#request-plugins)
 * [API Reference](#api-reference)
 * [Authorization and API Keys](#authorization-and-api-keys)
   * [Generate an API key](#generate-an-api-key)
@@ -206,6 +207,54 @@ Cloudant({hostname:"companycloudant.local", username:"somebody", password:"someb
 })
 ~~~
 
+### Request Plugins
+
+This library can be used with one of three `request` plugins:
+
+1. `default` - the default [request](https://www.npmjs.com/package/request) library plugin. This uses Node.js callbacks to communicate Cloudant's replies 
+back to your app and can be used to stream data using the Node.js Stream API.
+2. `promises` - if you'd prefer to write code in the Promises style then the "promises" plugin turns each request into a Promises. This plugin cannot be used 
+stream data.
+3. `retry` - on occasion, Cloudant's multi-tenant offerring may reply with an HTTP 429 response,  meaning "you've exceeded your call quota - try again later". 
+The "retry" plugin will automatically retry your request with exponential back-off.
+
+#### The 'promises' Plugins
+
+When initialising the Cloudant library, you can opt to use the 'promises' plugin:
+
+```js
+var cloudant = Cloudant({url: myurl, plugin:'promises'});
+var mydb = cloudant.db.use('mydb');
+```
+
+Then the library will return a Promise for every asynchronous call:
+
+```js
+mydb.list().then(function(data) {
+  console.log(data);
+}).catch(function(err) {
+  console.log('something went wrong', err);
+});
+```
+
+#### The 'retry' plugin
+
+When initialising the Cloudant library, you can opt to use the 'retry' plugin:
+
+```js
+var cloudant = Cloudant({url: myurl, plugin:'retry'});
+var mydb = cloudant.db.use('mydb');
+```
+
+Then use the Cloudant library normally. You may also opt to configure the retry parameters:
+
+- retryAttempts - the maximum number of times the request will be attempted (default 3)
+- retryTimeout - the number of milliseconds after the first attempt that the second request will be tried; the timeout doubling with each subsequent attempt  (default 500)
+
+```js
+var cloudant = Cloudant({url: myurl, plugin:'retry', retryAttempts:5, retryTimeout:1000 });
+var mydb = cloudant.db.use('mydb');
+```
 
 ## API Reference
 

--- a/README.md
+++ b/README.md
@@ -211,12 +211,13 @@ Cloudant({hostname:"companycloudant.local", username:"somebody", password:"someb
 
 This library can be used with one of three `request` plugins:
 
-1. `default` - the default [request](https://www.npmjs.com/package/request) library plugin. This uses Node.js callbacks to communicate Cloudant's replies 
-back to your app and can be used to stream data using the Node.js Stream API.
-2. `promises` - if you'd prefer to write code in the Promises style then the "promises" plugin turns each request into a Promises. This plugin cannot be used 
-stream data.
-3. `retry` - on occasion, Cloudant's multi-tenant offerring may reply with an HTTP 429 response,  meaning "you've exceeded your call quota - try again later". 
+1. `default` - the default [request](https://www.npmjs.com/package/request) library plugin. This uses Node.js's callbacks to communicate Cloudant's replies 
+back to your app and can be used to stream data using the Node.js [Stream API](https://nodejs.org/api/stream.html).
+2. `promises` - if you'd prefer to write code in the Promises style then the "promises" plugin turns each request into a Promise. This plugin cannot be used 
+stream data because instead of returning the HTTP request, we are simply returning a Promise instead.
+3. `retry` - on occasion, Cloudant's multi-tenant offerring may reply with an HTTP 429 response because you've exceed the number of API requests in a given amount of time. 
 The "retry" plugin will automatically retry your request with exponential back-off.
+4. custom plugin - you may also supply your own function which will be called to make API calls.
 
 #### The 'promises' Plugins
 
@@ -255,6 +256,20 @@ Then use the Cloudant library normally. You may also opt to configure the retry 
 var cloudant = Cloudant({url: myurl, plugin:'retry', retryAttempts:5, retryTimeout:1000 });
 var mydb = cloudant.db.use('mydb');
 ```
+
+#### Custom plugin
+
+When initialising the Cloudant library, you can supply your own plugin function:
+
+```js  
+  var doNothingPlugin = function(opts, callback) {
+    // don't do anything, just pretend that everything's ok.
+    callback(null, { statusCode:200 }, { ok: true});
+  };
+  var cloudant = Cloudant({url: myurl, plugin: doNothingPlugin});
+```
+
+Whenever the Cloudant library wishes to make an outgoing HTTP request, it will call your function instead of `request`. 
 
 ## API Reference
 

--- a/cloudant.js
+++ b/cloudant.js
@@ -57,8 +57,11 @@ function Cloudant(options, callback) {
     requestDefaults.agent = agent;
   } 
 
+  // plugin a request library
+  var plugin =  require('./plugins/retry.js');
+
   debug('Create underlying Nano instance, options=%j requestDefaults=%j', options, requestDefaults);
-  var nano = Nano({url:theurl, requestDefaults: requestDefaults, cookie: cookie, log: nanodebug});
+  var nano = Nano({url:theurl, request: plugin, requestDefaults: requestDefaults, cookie: cookie, log: nanodebug});
 
   // our own implementation of 'use' e.g. nano.use or nano.db.use
   // it includes all db-level functions

--- a/cloudant.js
+++ b/cloudant.js
@@ -58,9 +58,17 @@ function Cloudant(options, callback) {
   } 
 
   // plugin a request library
-  var plugintype = options.plugin || 'default';
-  debug('Using the "' + plugintype + '" plugin');
-  var plugin =  require('./plugins/' + plugintype)(options);
+  var plugin = null;
+  if (options.plugin) {
+    if(typeof options.plugin === 'string') {
+      var plugintype = options.plugin || 'default';
+      debug('Using the "' + plugintype + '" plugin');
+      plugin =  require('./plugins/' + plugintype)(options);
+    } else if (typeof options.plugin === 'function') { 
+      debug('Using a custom plugin');
+      plugin = options.plugin;
+    }
+  }
 
   debug('Create underlying Nano instance, options=%j requestDefaults=%j', options, requestDefaults);
   var nano = Nano({url:theurl, request: plugin, requestDefaults: requestDefaults, cookie: cookie, log: nanodebug});

--- a/cloudant.js
+++ b/cloudant.js
@@ -58,7 +58,7 @@ function Cloudant(options, callback) {
   } 
 
   // plugin a request library
-  var plugin =  require('./plugins/retry.js');
+  var plugin =  require('./plugins/promises.js')(options);
 
   debug('Create underlying Nano instance, options=%j requestDefaults=%j', options, requestDefaults);
   var nano = Nano({url:theurl, request: plugin, requestDefaults: requestDefaults, cookie: cookie, log: nanodebug});

--- a/cloudant.js
+++ b/cloudant.js
@@ -58,7 +58,9 @@ function Cloudant(options, callback) {
   } 
 
   // plugin a request library
-  var plugin =  require('./plugins/promises.js')(options);
+  var plugintype = options.plugin || 'default';
+  debug('Using the "' + plugintype + '" plugin');
+  var plugin =  require('./plugins/' + plugintype)(options);
 
   debug('Create underlying Nano instance, options=%j requestDefaults=%j', options, requestDefaults);
   var nano = Nano({url:theurl, request: plugin, requestDefaults: requestDefaults, cookie: cookie, log: nanodebug});

--- a/lib/reconfigure.js
+++ b/lib/reconfigure.js
@@ -47,9 +47,9 @@ module.exports = function(config) {
     if (match)
       config.account = match[1];
 
-    var credentials = getCredentials(config);
-    var username = credentials.username;
-    var password = credentials.password;
+    var options = getOptions(config);
+    var username = options.username;
+    var password = options.password;
 
     // Configure for Cloudant, either authenticated or anonymous.
     if (config.account && password) {
@@ -76,8 +76,8 @@ module.exports = function(config) {
   return outUrl;
 };
 
-module.exports.getCredentials = getCredentials;
-function getCredentials(config) {
+module.exports.getOptions = getOptions;
+function getOptions(config) {
   // The username is the account ("foo" for "foo.cloudant.com")
   // or the third-party API key.
   var result = {password:config.password, username: config.key || config.username || config.account};

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
   "dependencies": {
     "async": "^2.0.1",
     "debug": "2.2.0",
-    "nano": "6.2.0"
+    "nano": "6.2.0",
+    "request": "^2.53.0"
   },
   "devDependencies": {
     "dotenv": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "database"
   ],
   "dependencies": {
+    "async": "^2.0.1",
     "debug": "2.2.0",
     "nano": "6.2.0"
   },

--- a/plugins/default.js
+++ b/plugins/default.js
@@ -18,5 +18,6 @@
 // and can be used for with the Node.js streaming API.
 
 module.exports = function(options) {
-  return require('request');
+  var requestDefaults = options.requestDefaults || {jar: false};
+  return require('request').defaults(requestDefaults);
 }

--- a/plugins/default.js
+++ b/plugins/default.js
@@ -1,0 +1,6 @@
+// this the the 'default' request handler.
+// It is simply an instance of the popular 'request' npm module.
+// This is the simplest module to use as it supports JavaScript callbacks
+// and can be used for with the Node.js streaming API.
+
+module.exports = require('request');

--- a/plugins/default.js
+++ b/plugins/default.js
@@ -3,4 +3,6 @@
 // This is the simplest module to use as it supports JavaScript callbacks
 // and can be used for with the Node.js streaming API.
 
-module.exports = require('request');
+module.exports = function(options) {
+  return require('request');
+}

--- a/plugins/default.js
+++ b/plugins/default.js
@@ -1,3 +1,17 @@
+/**
+ * Copyright (c) 2015 IBM Cloudant, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
 // this the the 'default' request handler.
 // It is simply an instance of the popular 'request' npm module.
 // This is the simplest module to use as it supports JavaScript callbacks

--- a/plugins/promises.js
+++ b/plugins/promises.js
@@ -5,21 +5,28 @@ var request = require('request');
 
 var nullcallback = function() {};
 
-module.exports = function(req, callback) {
-  if (typeof callback !== 'function') {
-    callback = nullcallback;
-  }
-  return new Promise(function(resolve, reject) {
-    request(req, function(err, h, b) {
-      var statusCode = h && h.statusCode || 500;
-      if (statusCode >= 200 && statusCode < 400) {
-        callback(null, b);
-        return resolve(b);
-      }
-      reject(b);
-      callback(err, b);
-    })
-  });
+
+
+module.exports = function(options) {
+
+  var myrequest = function(req, callback) {
+    if (typeof callback !== 'function') {
+      callback = nullcallback;
+    }
+    return new Promise(function(resolve, reject) {
+      request(req, function(err, h, b) {
+        var statusCode = h && h.statusCode || 500;
+        if (statusCode >= 200 && statusCode < 400) {
+          callback(null, h, b);
+          return resolve(b);
+        }
+        reject(b);
+        callback(err, h, b);
+      })
+    });
+  };
+
+  return myrequest;
 };
     
     

--- a/plugins/promises.js
+++ b/plugins/promises.js
@@ -15,12 +15,13 @@
 // this the the 'promises' request handler.
 // It is a function that returns a Promise and resolves the promise on success 
 // or rejects the Promise on failure
-var request = require('request');
 
 var nullcallback = function() {};
 
 module.exports = function(options) {
 
+  var requestDefaults = options.requestDefaults || {jar: false};
+  var request = require('request').defaults(requestDefaults);
   var myrequest = function(req, callback) {
     if (typeof callback !== 'function') {
       callback = nullcallback;
@@ -32,8 +33,8 @@ module.exports = function(options) {
           callback(null, h, b);
           return resolve(b);
         }
-        reject(b);
-        callback(err, h, sb);
+        reject(err || b);
+        callback(err, h, b);
       })
     });
   };

--- a/plugins/promises.js
+++ b/plugins/promises.js
@@ -1,0 +1,25 @@
+// this the the 'promises' request handler.
+// It is a function that returns a Promise and resolves the promise on success 
+// or rejects the Promise on failure
+var request = require('request');
+
+var nullcallback = function() {};
+
+module.exports = function(req, callback) {
+  if (typeof callback !== 'function') {
+    callback = nullcallback;
+  }
+  return new Promise(function(resolve, reject) {
+    request(req, function(err, h, b) {
+      var statusCode = h && h.statusCode || 500;
+      if (statusCode >= 200 && statusCode < 400) {
+        callback(null, b);
+        return resolve(b);
+      }
+      reject(b);
+      callback(err, b);
+    })
+  });
+};
+    
+    

--- a/plugins/promises.js
+++ b/plugins/promises.js
@@ -21,7 +21,7 @@ module.exports = function(options) {
           return resolve(b);
         }
         reject(b);
-        callback(err, h, b);
+        callback(err, h, sb);
       })
     });
   };

--- a/plugins/promises.js
+++ b/plugins/promises.js
@@ -1,11 +1,23 @@
+/**
+ * Copyright (c) 2015 IBM Cloudant, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
 // this the the 'promises' request handler.
 // It is a function that returns a Promise and resolves the promise on success 
 // or rejects the Promise on failure
 var request = require('request');
 
 var nullcallback = function() {};
-
-
 
 module.exports = function(options) {
 

--- a/plugins/retry.js
+++ b/plugins/retry.js
@@ -1,3 +1,17 @@
+/**
+ * Copyright (c) 2015 IBM Cloudant, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
 // this the the 'retry' request handler.
 // If CouchDB/Cloudant responds with a 429 HTTP code
 // the library will retry the request up to three

--- a/plugins/retry.js
+++ b/plugins/retry.js
@@ -11,8 +11,8 @@ module.exports = function(options) {
   
   var myrequest = function(req, callback) {
     var attempts = 0;
-    var maxAttempts = 3;
-    var firstTimeout = 500; // ms
+    var maxAttempts = options.retryAttempts || 3;
+    var firstTimeout = options.retryTimeout || 500; // ms
     var timeout = 0; // ms
     var statusCode = null;
 

--- a/plugins/retry.js
+++ b/plugins/retry.js
@@ -7,40 +7,44 @@ var request = require('request');
 var async = require('async');
 var debug = require('debug')('cloudant');
 
-module.exports = function(req, callback) {
-  var attempts = 0;
-  var maxAttempts = 3;
-  var firstTimeout = 500; // ms
-  var timeout = 0; // ms
-  var statusCode = null;
+module.exports = function(options) {
+  
+  var myrequest = function(req, callback) {
+    var attempts = 0;
+    var maxAttempts = 3;
+    var firstTimeout = 500; // ms
+    var timeout = 0; // ms
+    var statusCode = null;
 
-  // do the first function until the second function returns true
-  async.doUntil(function(done) {
-    attempts++;
-    if (attempts > 1) {
-      debug('attempt', attempts, 'timeout', timeout);
-    }
-    setTimeout(function() {
-      request(req, function(e, h, b) {
-        statusCode = h && h.statusCode || 500;
-        done(null, [e, h, b]);
-      });  
-    }, timeout);
-  }, function() {
-    // this function returns false for the first 'maxAttempts' 429s receieved
-    if (statusCode === 429 && attempts < maxAttempts) {
-      if (attempts === 1) {
-        timeout = firstTimeout;
-      } else {
-        timeout *= 2;
+    // do the first function until the second function returns true
+    async.doUntil(function(done) {
+      attempts++;
+      if (attempts > 1) {
+        debug('attempt', attempts, 'timeout', timeout);
       }
-      return false;
-    } 
-    return true;
-  }, function(e, results) {
-     callback(results[0], results[1], results[2])
-  });
+      setTimeout(function() {
+        request(req, function(e, h, b) {
+          statusCode = h && h.statusCode || 500;
+          done(null, [e, h, b]);
+        });  
+      }, timeout);
+    }, function() {
+      // this function returns false for the first 'maxAttempts' 429s receieved
+      if (statusCode === 429 && attempts < maxAttempts) {
+        if (attempts === 1) {
+          timeout = firstTimeout;
+        } else {
+          timeout *= 2;
+        }
+        return false;
+      } 
+      return true;
+    }, function(e, results) {
+      callback(results[0], results[1], results[2])
+    });
+  };
 
+  return myrequest;
 };
     
     

--- a/plugins/retry.js
+++ b/plugins/retry.js
@@ -1,0 +1,47 @@
+// this the the 'retry' request handler.
+// If CouchDB/Cloudant responds with a 429 HTTP code
+// the library will retry the request up to three
+// times with exponential backoff.
+// This module is unsuitable for streaming requests.
+var request = require('request');
+var async = require('async');
+var debug = require('debug')('cloudant');
+
+module.exports = function(req, callback) {
+  var attempts = 0;
+  var maxAttempts = 3;
+  var firstTimeout = 500; // ms
+  var timeout = 0; // ms
+  var statusCode = null;
+
+  // do the first function until the second function returns true
+  async.doUntil(function(done) {
+    attempts++;
+    if (attempts > 1) {
+      debug('attempt', attempts, 'timeout', timeout);
+    }
+    setTimeout(function() {
+      request(req, function(e, h, b) {
+        statusCode = h && h.statusCode || 500;
+        done(null, [e, h, b]);
+      });  
+    }, timeout);
+  }, function() {
+    // this function returns false for the first 'maxAttempts' 429s receieved
+    if (statusCode === 429 && attempts < maxAttempts) {
+      if (attempts === 1) {
+        timeout = firstTimeout;
+      } else {
+        timeout *= 2;
+      }
+      return false;
+    } 
+    return true;
+  }, function(e, results) {
+     callback(results[0], results[1], results[2])
+  });
+
+};
+    
+    
+    

--- a/plugins/retry.js
+++ b/plugins/retry.js
@@ -17,12 +17,13 @@
 // the library will retry the request up to three
 // times with exponential backoff.
 // This module is unsuitable for streaming requests.
-var request = require('request');
 var async = require('async');
 var debug = require('debug')('cloudant');
 
 module.exports = function(options) {
-  
+  var requestDefaults = options.requestDefaults || {jar: false};
+  var request = require('request').defaults(requestDefaults);
+
   var myrequest = function(req, callback) {
     var attempts = 0;
     var maxAttempts = options.retryAttempts || 3;

--- a/tests/plugin.js
+++ b/tests/plugin.js
@@ -36,20 +36,8 @@ var viewname = null;
 
 describe('retry-on-429 plugin', function() {
 
-  it('should return a 429', function(done) {
-    var cloudant = Cloudant({plugin:'retry', url: 'https://mock429.eu-gb.mybluemix.net/'});
-    var db = cloudant.db.use('test');
-    this.timeout(10000);
-    db.info(function(err, data) {
-      err.should.be.an.Object;
-      err.should.have.property('statusCode');
-      err.statusCode.should.be.a.Number;
-      err.statusCode.should.equal(429);
-      done();
-    })
-  });
-
   it('behave normally too', function(done) {
+    var mocks = nock(SERVER).get('/' + MYDB).reply(200, {});
     var cloudant = Cloudant({plugin:'retry', account:ME, password: PASSWORD});
     var db = cloudant.db.use(MYDB);
     this.timeout(10000);
@@ -64,6 +52,8 @@ describe('retry-on-429 plugin', function() {
 describe('promise plugin', function() {
 
   it('should return a promise', function(done) {
+    var mocks = nock(SERVER)
+      .get('/' + MYDB).reply(200, {});
     var cloudant = Cloudant({plugin:'promises', account:ME, password: PASSWORD});
     var db = cloudant.db.use(MYDB);
     var p = db.info().then(function(data) {

--- a/tests/plugin.js
+++ b/tests/plugin.js
@@ -1,0 +1,97 @@
+/**
+ * Copyright (c) 2015 IBM Cloudant, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+// Cloudant client API tests
+require('dotenv').config();
+
+var fs = require('fs');
+var should = require('should');
+var assert = require('assert');
+
+var nock = require('./nock.js');
+var Cloudant = require('../cloudant.js');
+
+
+// These globals may potentially be parameterized.
+var ME = process.env.cloudant_username || 'nodejs';
+var PASSWORD = process.env.cloudant_password || null;
+var SERVER = 'https://' + ME + '.cloudant.com';
+var MYDB = 'mydb';
+var mydb = null;
+var cc = null;
+var ddoc = null;
+var viewname = null;
+
+
+describe('retry-on-429 plugin', function() {
+
+  it('should return a 429', function(done) {
+    var cloudant = Cloudant({plugin:'retry', url: 'https://mock429.eu-gb.mybluemix.net/'});
+    var db = cloudant.db.use('test');
+    this.timeout(10000);
+    db.info(function(err, data) {
+      err.should.be.an.Object;
+      err.should.have.property('statusCode');
+      err.statusCode.should.be.a.Number;
+      err.statusCode.should.equal(429);
+      done();
+    })
+  });
+
+  it('behave normally too', function(done) {
+    var cloudant = Cloudant({plugin:'retry', account:ME, password: PASSWORD});
+    var db = cloudant.db.use(MYDB);
+    this.timeout(10000);
+    db.info(function(err, data) {
+      assert.equal(err, null);
+      data.should.be.an.Object;
+      done();
+    })
+  })
+});
+
+describe('promise plugin', function() {
+
+  it('should return a promise', function(done) {
+    var cloudant = Cloudant({plugin:'promises', account:ME, password: PASSWORD});
+    var db = cloudant.db.use(MYDB);
+    var p = db.info().then(function(data) {
+      data.should.be.an.object;
+      done();
+    });
+    assert.equal(p instanceof Promise, true);
+  })
+
+});
+
+describe('custom plugin', function() {
+
+  var doNothingPlugin = function(opts, callback) {
+    callback(null, { statusCode:200 }, { ok: true});
+  };
+
+  it('should allow custom plugins', function(done) {
+    var cloudant = Cloudant({plugin: doNothingPlugin, account:ME, password: PASSWORD});
+    var db = cloudant.db.use(MYDB);
+    db.info(function(err, data) {
+      assert.equal(err, null);
+      data.should.be.an.Object;
+      data.should.have.property.ok;
+      data.ok.should.be.a.boolean;
+      data.ok.should.equal(true);
+      done();
+    });
+  })
+
+});

--- a/tests/readme-examples.js
+++ b/tests/readme-examples.js
@@ -27,6 +27,9 @@ require('dotenv').config();
 var should = require('should');
 
 var nock = require('./nock.js');
+var ME = process.env.cloudant_username || 'nodejs';
+var PASSWORD = process.env.cloudant_password || null;
+var SERVER = 'https://' + ME + '.cloudant.com';
 
 var real_require = require;
 require = function(module) {
@@ -44,7 +47,7 @@ describe('Getting Started', function() {
 
   var mocks;
   before(function() {
-    mocks = nock('https://nodejs.cloudant.com')
+    mocks = nock(SERVER)
       .get('/_all_dbs').reply(200, ['database_changes', 'third_party_db'])
       .delete('/alice').reply(404, {error:'not_found', reason:'Database does not exist.'})
       .put('/alice').reply(201, {ok:true})
@@ -59,7 +62,7 @@ describe('Getting Started', function() {
     // Load the Cloudant library.
     var Cloudant = require('cloudant');
 
-    var me = 'nodejs'; // Set this to your own account
+    var me = ME; // Set this to your own account
     var password = process.env.cloudant_password;
 
     // Initialize the library with my account.
@@ -73,13 +76,13 @@ describe('Getting Started', function() {
   });
 
   it('Example 2', function(done) {
-    require('dotenv').load();
+
 
     // Load the Cloudant library.
     var Cloudant = require('cloudant');
 
     // Initialize Cloudant with settings from .env
-    var username = process.env.cloudant_username || "nodejs";
+    var username = ME;
     var password = process.env.cloudant_password;
     var cloudant = Cloudant({account:username, password:password});
 
@@ -116,8 +119,8 @@ describe('Initialization', function() {
   var mocks;
   after(function() { mocks.done(); });
   before(function() {
-    mocks = nock('https://nodejs.cloudant.com')
-      .get('/_session').reply(200, {ok:true, userCtx:{name:'nodejs', roles:[]}})
+    mocks = nock(SERVER)
+      .get('/_session').reply(200, {ok:true, userCtx:{name:ME, roles:[]}})
       .post('/_session').reply(200, {XXXXX:'YYYYYYYYYY', ok:true, userCtx:{name:'jhs', roles:[]}})
       .get('/').reply(200, {couchdb:'Welcome', version:'1.0.2', cloudant_build:'2488'})
       .get('/animals/dog').reply(404, {error:'not_found', reason:'missing'});
@@ -125,7 +128,7 @@ describe('Initialization', function() {
 
   it('Example 1', function(done) {
     var Cloudant = require('cloudant');
-    var me = 'nodejs'; // Replace with your account.
+    var me = ME; // Replace with your account.
     var password = process.env.cloudant_password;
 
     Cloudant({account:me, password:password}, function(err, cloudant) {
@@ -147,7 +150,7 @@ describe('Password authentication', function() {
   var mocks;
   after(function() { mocks.done(); });
   before(function() {
-    mocks = nock('https://nodejs.cloudant.com')
+    mocks = nock(SERVER)
       .get('/_session').reply(200, {XXXXX:'YYYYYYYYYY', ok:true, userCtx:{name:'jhs', roles:[]}})
       .post('/_session').reply(200, {XXXXX:'YYYYYYYYYY', ok:true, userCtx:{name:'jhs', roles:[]}})
       .get('/').reply(200, {couchdb:'Welcome!!!!!', version:'1.0.2', cloudant_build:'2488'});
@@ -155,7 +158,7 @@ describe('Password authentication', function() {
 
   it('Example 1', function(done) {
     var Cloudant = require('cloudant');
-    var me = "nodejs";         // Substitute with your Cloudant user account.
+    var me = ME;         // Substitute with your Cloudant user account.
     var otherUsername = "jhs"; // Substitute with some other Cloudant user account.
     var otherPassword = process.env.other_cloudant_password;
 
@@ -180,7 +183,7 @@ describe('Authorization and API Keys', function() {
   var mocks;
   after(function() { mocks.done(); });
   before(function() {
-    mocks = nock('https://nodejs.cloudant.com')
+    mocks = nock(SERVER)
       .post('/_api/v2/api_keys')
       .reply(200, { "password": "Eivln4jPiLS8BoTxjXjVukDT", "ok": true, "key": "thandoodstrenterprourete" })
       .put('/_api/v2/db/animals/_security')
@@ -191,7 +194,7 @@ describe('Authorization and API Keys', function() {
 
   it('Example 1', function(done) {
     var Cloudant = require('cloudant');
-    var me = 'nodejs'; // Replace with your account.
+    var me = ME; // Replace with your account.
     var password = process.env.cloudant_password;
     var cloudant = Cloudant({account:me, password:password});
 
@@ -246,7 +249,7 @@ describe('CORS', function() {
   var mocks;
   after(function() { mocks.done(); });
   before(function() {
-    mocks = nock('https://nodejs.cloudant.com')
+    mocks = nock(SERVER)
       .put('/_api/v2/user/config/cors')
       .reply(200, {ok:true})
       .put('/_api/v2/user/config/cors')
@@ -260,7 +263,7 @@ describe('CORS', function() {
   var cloudant;
   before(function() {
     var Cloudant = require('cloudant');
-    cloudant = Cloudant({account:'nodejs', password:process.env.cloudant_password});
+    cloudant = Cloudant({account:ME, password:process.env.cloudant_password});
   });
 
   it('Example 1', function(done) {
@@ -305,7 +308,7 @@ describe('Virtual Hosts', function() {
   var mocks;
   after(function() { mocks.done(); });
   before(function() {
-    mocks = nock('https://nodejs.cloudant.com')
+    mocks = nock(SERVER)
       .post('/_api/v2/user/virtual_hosts')
       .reply(200, {ok:true})
       .get('/_api/v2/user/virtual_hosts')
@@ -317,7 +320,7 @@ describe('Virtual Hosts', function() {
   var cloudant;
   before(function() {
     var Cloudant = require('cloudant');
-    cloudant = Cloudant({account:'nodejs', password:process.env.cloudant_password});
+    cloudant = Cloudant({account:ME, password:process.env.cloudant_password});
   });
 
   it('Example 1', function(done) {
@@ -350,7 +353,7 @@ describe('Cloudant Query', function() {
 
   var mocks;
   before(function() {
-    mocks = nock('https://nodejs.cloudant.com')
+    mocks = nock(SERVER)
       .put('/my_db')
       .reply(200, {ok:true})
       .get('/my_db/_index')
@@ -366,7 +369,7 @@ describe('Cloudant Query', function() {
   var cloudant, db;
   before(function(done) {
     var Cloudant = require('cloudant');
-    cloudant = Cloudant({account:'nodejs', password:process.env.cloudant_password});
+    cloudant = Cloudant({account:ME, password:process.env.cloudant_password});
     cloudant.db.create('my_db', function(er) {
       if (er) throw er;
       db = cloudant.db.use('my_db')
@@ -432,7 +435,7 @@ describe('Cloudant Search', function() {
 
   var mocks;
   before(function() {
-    mocks = nock('https://nodejs.cloudant.com')
+    mocks = nock(SERVER)
       .put('/my_db')
       .reply(200, {ok:true})
       .post('/my_db/_bulk_docs')
@@ -450,7 +453,7 @@ describe('Cloudant Search', function() {
   var cloudant, db;
   before(function(done) {
     var Cloudant = require('cloudant');
-    cloudant = Cloudant({account:'nodejs', password:process.env.cloudant_password});
+    cloudant = Cloudant({account:ME, password:process.env.cloudant_password});
     cloudant.db.create('my_db', function(er) {
       if (er) throw er;
       db = cloudant.db.use('my_db')
@@ -537,17 +540,17 @@ describe('Cookie Authentication', function() {
 
   var mocks;
   before(function() {
-    mocks = nock('https://nodejs.cloudant.com')
+    mocks = nock(SERVER)
       .post('/_session')
-      .reply(200, { ok: true, name: 'nodejs', roles: [] },
+      .reply(200, { ok: true, name: ME, roles: [] },
         {'set-cookie': ['AuthSession=bm9kZWpzOjU1RTA1NDdEOsUsoq9lykQCEBhwTpIyEbgmYpvX; Version=1; Expires=Sat, 29 Aug 2015 12:30:53 GMT; Max-Age=86400; Path=/; HttpOnly; Secure']})
       .post('/alice')
       .reply(200, { ok: true, id: '72e0367f3e195340e239948164bbb7e7', rev: '1-feb5539029f4fc50dc3f827b164a2088' })
       .get('/_session')
-      .reply(200, {ok:true, userCtx:{name:'nodejs',roles:['_admin','_reader','_writer']}});
+      .reply(200, {ok:true, userCtx:{name:ME,roles:['_admin','_reader','_writer']}});
 
     var Cloudant = require('cloudant');
-    cloudant = Cloudant({account:'nodejs', password:process.env.cloudant_password});
+    cloudant = Cloudant({account:ME, password:process.env.cloudant_password});
   });
 
   after(function() {
@@ -558,7 +561,7 @@ describe('Cookie Authentication', function() {
 
   it('Example 1', function(done) {
     var Cloudant = require('cloudant');
-    var username = 'nodejs'; // Set this to your own account
+    var username = ME; // Set this to your own account
     var password = process.env.cloudant_password;
     var cloudant = Cloudant({account:username, password:password});
 
@@ -589,7 +592,7 @@ describe('Cookie Authentication', function() {
   it('Example 2', function(done) {
     // Make a new connection with the cookie.
     var Cloudant = require('cloudant');
-    var username = 'nodejs'; // Set this to your own account
+    var username = ME; // Set this to your own account
     var other_cloudant = Cloudant({account:username, cookie:cookies[username]});
 
     var alice = other_cloudant.db.use('alice')
@@ -614,7 +617,7 @@ describe('Cookie Authentication', function() {
     // (Presuming the "cookie" global from the above example is still in scope.)
 
     var Cloudant = require('cloudant');
-    var username = 'nodejs'; // Set this to your own account
+    var username = ME; // Set this to your own account
     var cloudant = Cloudant({account:username, cookie:cookies[username]});
 
     cloudant.session(function(er, session) {

--- a/tests/readme-examples.js
+++ b/tests/readme-examples.js
@@ -152,7 +152,7 @@ describe('Password authentication', function() {
   before(function() {
     mocks = nock(SERVER)
       .get('/_session').reply(200, {XXXXX:'YYYYYYYYYY', ok:true, userCtx:{name:'jhs', roles:[]}})
-      .post('/_session').reply(200, {XXXXX:'YYYYYYYYYY', ok:true, userCtx:{name:'jhs', roles:[]}})
+      //.post('/_session').reply(200, {XXXXX:'YYYYYYYYYY', ok:true, userCtx:{name:'jhs', roles:[]}})
       .get('/').reply(200, {couchdb:'Welcome!!!!!', version:'1.0.2', cloudant_build:'2488'});
   });
 


### PR DESCRIPTION
Allows the `request` library to be replaced at runtime. Options are:

- 'default' - the normal request library
- 'retry' - retry the request with exponential back-off if a 429 response is received
- 'promises' - returns a Promise instead of a request object
- custom - supply your own request-compatible function