### PR TITLE
make retry plugin return a stream. Fixes issue #154

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ back to your app and can be used to stream data using the Node.js [Stream API](h
 2. `promises` - if you'd prefer to write code in the Promises style then the "promises" plugin turns each request into a Promise. This plugin cannot be used 
 stream data because instead of returning the HTTP request, we are simply returning a Promise instead.
 3. `retry` - on occasion, Cloudant's multi-tenant offerring may reply with an HTTP 429 response because you've exceed the number of API requests in a given amount of time. 
-The "retry" plugin will automatically retry your request with exponential back-off.
+The "retry" plugin will automatically retry your request with exponential back-off. The 'retry' plugin can be used to stream data.
 4. custom plugin - you may also supply your own function which will be called to make API calls.
 
 #### The 'promises' Plugins

--- a/tests/plugin.js
+++ b/tests/plugin.js
@@ -21,6 +21,7 @@ var assert = require('assert');
 
 var nock = require('./nock.js');
 var Cloudant = require('../cloudant.js');
+var stream = require('stream');
 
 
 // These globals may potentially be parameterized.
@@ -55,7 +56,18 @@ describe('retry-on-429 plugin', function() {
     this.timeout(10000);
     db.info();
     setTimeout(done, 1000);
-  })
+  });
+
+  it('should return a stream', function(done) {
+    var mocks = nock(SERVER)
+      .get('/' + MYDB).reply(200, { ok: true});
+    var cloudant = Cloudant({plugin:'retry', account:ME, password: PASSWORD});
+    var db = cloudant.db.use(MYDB);
+    var p = db.info(function() {
+      done();
+    });
+    assert.equal(p instanceof stream.PassThrough, true);
+  });
 });
 
 describe('promise plugin', function() {


### PR DESCRIPTION
Modifies the retry plugin to make it return a stream.PassThrough object which is fed content from a successful (non-429) request. This allows the pipe operator to be used.