### PR TITLE
Add option to initialize Cloudant using VCAP

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,15 @@ var Cloudant = require('cloudant')
 var cloudant = Cloudant("https://MYUSERNAME:MYPASSWORD@MYACCOUNT.cloudant.com");
 ~~~
 
+Running on Bluemix? You can initialize Cloudant directly from the `VCAP_SERVICES` environment variable:
+
+~~~ js
+var Cloudant = require('cloudant');
+var cloudant = Cloudant({instanceName: 'foo', vcapServices: JSON.parse(process.env.VCAP_SERVICES)});
+~~~
+
+Note, if you only have a single Cloudant service then specifying the `instanceName` isn't required.
+
 You can optionally provide a callback to the Cloudant initialization function. This will make the library automatically "ping" Cloudant to confirm the connection and that your credentials work.
 
 Here is a simple example of initializing asychronously, using its optional callback parameter:

--- a/lib/reconfigure.js
+++ b/lib/reconfigure.js
@@ -6,6 +6,7 @@
 // or   { account:"myaccount.cloudant.com", password: "mykey"}
 // or   { account: "myaccount"}
 // or   { url: "https://mykey:mypassword@myaccount.cloudant.com"}
+// or   { instanceName: "mycloudantservice", vcapServices: JSON.parse(process.env.VCAP_SERVICES)}
 
 var url = require('url');
 
@@ -38,7 +39,30 @@ module.exports = function(config) {
     }
     
     outUrl = config.url;
-  
+
+  } else if (config.vcapServices) {
+    cloudantServices = config.vcapServices.cloudantNoSQLDB;
+
+    if (!cloudantServices || cloudantServices.length == 0) {
+      throw new Error('Missing Cloudant service in vcapServices');
+    }
+
+    for (var i = 0; i < cloudantServices.length; i++) {
+      if (config.instanceName == undefined || cloudantServices[i].name == config.instanceName) {
+        var credentials = cloudantServices[i].credentials;
+        if (credentials && credentials.url) {
+          outUrl = credentials.url;
+          break;
+        } else {
+          throw new Error('Invalid Cloudant service in vcapServices');
+        }
+      }
+    }
+
+    if (!outUrl) {
+      throw new Error('Missing Cloudant service in vcapServices');
+    }
+
   } else {
     // An account can be just the username, or the full cloudant URL.
     var match = config.account &&

--- a/tests/reconfigure.js
+++ b/tests/reconfigure.js
@@ -182,6 +182,8 @@ describe('Reconfigure', function() {
       {name: "serviceA", credentials: {}} // invalid service, missing url
     ]}};
     should(function () { reconfigure(config); }).throw("Invalid Cloudant service in vcapServices");
+    done();
+  });
 
   it('detects bad urls', function(done) {
     var credentials = { url: 'invalid' };

--- a/tests/reconfigure.js
+++ b/tests/reconfigure.js
@@ -103,4 +103,85 @@ describe('Reconfigure', function() {
     done();
   });
 
+  it('gets first URL from vcap containing single service', function(done) {
+    var config = {vcapServices: {cloudantNoSQLDB: [
+      {credentials: {url: "http://mykey:mypassword@mydomain.cloudant.com"}}
+    ]}};
+    var url = reconfigure(config);
+    url.should.be.a.String;
+    url.should.equal("http://mykey:mypassword@mydomain.cloudant.com");
+    done();
+  });
+
+  it('gets URL by instance name from vcap containing single service', function(done) {
+    var config = {instanceName: "serviceA", vcapServices: {cloudantNoSQLDB: [
+      {name: "serviceA", credentials: {url: "http://mykey:mypassword@mydomain.cloudant.com"}}
+    ]}};
+    var url = reconfigure(config);
+    url.should.be.a.String;
+    url.should.equal("http://mykey:mypassword@mydomain.cloudant.com");
+    done();
+  });
+
+  it('gets first URL from vcap containing multiple services', function(done) {
+    var config = {vcapServices: {cloudantNoSQLDB: [
+      {credentials: {url: "http://mykey:mypassword@mydomain.cloudant.com"}},
+      {credentials: {url: "http://foo.bar"}},
+      {credentials: {url: "http://foo.bar"}}
+    ]}};
+    var url = reconfigure(config);
+    url.should.be.a.String;
+    url.should.equal("http://mykey:mypassword@mydomain.cloudant.com");
+    done();
+  });
+
+  it('gets URL by instance name from vcap containing multiple services', function(done) {
+    var config = {instanceName: 'serviceC', vcapServices: {cloudantNoSQLDB: [
+      {name: "serviceA", credentials: {url: "http://foo.bar"}},
+      {name: "serviceB", credentials: {url: "http://foo.bar"}},
+      {name: "serviceC", credentials: {url: "http://mykey:mypassword@mydomain.cloudant.com"}}
+    ]}};
+    var url = reconfigure(config);
+    url.should.be.a.String;
+    url.should.equal("http://mykey:mypassword@mydomain.cloudant.com");
+    done();
+  });
+
+  it('errors for empty vcap', function(done) {
+    var config = {vcapServices: {}}
+    should(function () { reconfigure(config); }).throw("Missing Cloudant service in vcapServices");
+    done();
+  });
+
+  it('errors for no services in vcap', function(done) {
+    var config = {vcapServices: {cloudantNoSQLDB: []}}
+    should(function () { reconfigure(config); }).throw("Missing Cloudant service in vcapServices");
+    done();
+  });
+
+  it('errors for missing service in vcap', function(done) {
+    var config = {instanceName: 'serviceC', vcapServices: {cloudantNoSQLDB: [
+      {name: "serviceA", credentials: {url: "http://foo.bar"}},
+      {name: "serviceB", credentials: {url: "http://foo.bar"}} // missing "serviceC"
+    ]}};
+    should(function () { reconfigure(config); }).throw("Missing Cloudant service in vcapServices");
+    done();
+  });
+
+  it('errors for invalid service in vcap - missing credentials', function(done) {
+    var config = {vcapServices: {cloudantNoSQLDB: [
+      {name: "serviceA"} // invalid service, missing credentials
+    ]}};
+    should(function () { reconfigure(config); }).throw('Invalid Cloudant service in vcapServices');
+    done();
+  });
+
+  it('errors for invalid service in vcap - missing url', function(done) {
+    var config = {vcapServices: {cloudantNoSQLDB: [
+      {name: "serviceA", credentials: {}} // invalid service, missing url
+    ]}};
+    should(function () { reconfigure(config); }).throw("Invalid Cloudant service in vcapServices");
+    done();
+  });
+
 });


### PR DESCRIPTION
Initialize Cloudant by parsing a VCAP_SERVICES environment variable
allowing easy binding of a service instance to a Cloud Foundry
application.

Example usage:
```
var cloudant = Cloudant({vcapServices: JSON.parse(process.env.VCAP_SERVICES)});
```

Fixes #173.