### PR TITLE
Create .npmignore and ignore examples and tests

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,2 @@
+example
+tests


### PR DESCRIPTION
This pull request adds a `.npmignore` file. The idea is to not publish the `example` or `tests` folder into npm.