### PR TITLE
Add Cloudant client

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -1,0 +1,234 @@
+// Copyright © 2017 IBM Corp. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+'use strict';
+
+const async = require('async');
+const debug = require('debug')('client');
+const EventPipe = require('./eventpipe.js');
+const pkg = require('../package.json');
+const stream = require('stream');
+const utils = require('./clientutils.js');
+
+/**
+ * Create a Cloudant client for managing requests.
+ *
+ * @param {Object} opts - Request options.
+ */
+function CloudantClient(opts) {
+  this._opts = opts || {};
+
+  this._plugins = [];
+  this._usePromises = false;
+
+  // initialize the internal client
+  this._initClient();
+
+  // add plugins
+  if (this._opts.plugin) {
+    this.addPlugins(this._opts.plugin);
+  }
+  // alias
+  if (this._opts.plugins) {
+    this.addPlugins(this._opts.plugins);
+  }
+}
+
+CloudantClient.prototype._initClient = function() {
+  var protocol;
+  if (this._opts && this._opts.https === false) {
+    protocol = require('http');
+  } else {
+    protocol = require('https'); // default to https
+  }
+
+  var agent = new protocol.Agent({
+    keepAlive: true,
+    keepAliveMsecs: 30000,
+    maxSockets: 6
+  });
+  var requestDefaults = {
+    agent: agent,
+    gzip: true,
+    headers: {
+      // set library UA header
+      'User-Agent': `nodejs-cloudant/${pkg.version} (Node.js ${process.version})`
+    },
+    jar: false
+  };
+
+  if (this._opts.requestDefaults) {
+    // allow user to override defaults
+    requestDefaults = Object.assign({}, requestDefaults, this._opts.requestDefaults);
+  }
+
+  this._client = require('request').defaults(requestDefaults);
+};
+
+CloudantClient.prototype._doPromisesRequest = function(options, callback) {
+  var self = this;
+
+  return new Promise(function(resolve, reject) {
+    self._doRequest(options, function(error, response, data) {
+      if (typeof callback !== 'undefined') {
+        callback(error, response, data);
+      }
+      if (error) {
+        reject(error);
+      } else {
+        if (data) {
+          try {
+            data = JSON.parse(data);
+            data.statusCode = response.statusCode;
+          } catch (err) {}
+        } else {
+          data = { statusCode: response.statusCode };
+        }
+        if (response.statusCode >= 200 && response.statusCode < 400) {
+          resolve(data);
+        } else {
+          reject(data);
+        }
+      }
+    });
+  });
+};
+
+CloudantClient.prototype._doRequest = function(options, callback) {
+  var self = this;
+
+  if (typeof options === 'string') {
+    options = { method: 'GET', url: options };  // default GET
+  }
+
+  var request = {};
+  request.clientCallback = callback;
+  request.clientStream = new stream.PassThrough();
+  request.clientStream.on('error', function(err) {
+    debug(err);
+  });
+
+  request.plugins = self._plugins;
+
+  // init state
+  request.state = {
+    attempt: 0,
+    maxAttempt: self._opts.maxAttempt || 3,
+    // following are editable by plugin hooks during execution
+    retry: false,
+    retryDelay: 0,
+    abortWithResponse: undefined
+  };
+
+  async.doUntil(function(done) {
+    request.options = Object.assign({}, options); // new copy
+    request.response = undefined;
+
+    // update state
+    request.state.attempt++;
+    request.state.retry = false;
+
+    async.series([
+      function(callback) {
+        utils.runHooks('onRequest', request, request.options, callback);
+      },
+      function(callback) {
+        utils.processState(request, callback); // process request hook results
+      }
+    ], function(stop) {
+      if (stop) {
+        return done(stop); // request hooks failed
+      }
+      setTimeout(function() {
+        // do request
+        request.response = self._client(
+          request.options, utils.wrapCallback(request, done));
+
+        // pipe to client stream
+        request.eventPipe = new EventPipe(request.response, request.clientStream);
+
+        if (typeof request.clientCallback === 'undefined') {
+          // run hooks using response event listener
+          request.response
+            .on('error', function(error) {
+              utils.runHooks('onError', request, error, function() {
+                utils.processState(request, done); // process error hook results
+              });
+            })
+            .on('response', function(response) {
+              utils.runHooks('onResponse', request, response, function() {
+                utils.processState(request, done); // process response hook results
+              });
+            });
+        }
+      }, request.state.retryDelay);
+    });
+  }, function(stop) {
+    return stop;
+  });
+
+  // return stream to client
+  return request.clientStream;
+};
+
+// public
+
+/**
+ * Add plugins to this Cloudant client.
+ *
+ * @param {Object[]} plugins - Array of plugins to add.
+ */
+CloudantClient.prototype.addPlugins = function(plugins) {
+  var self = this;
+
+  if (!Array.isArray(plugins)) {
+    plugins = [plugins];
+  }
+
+  plugins.forEach(function(Plugin) {
+    // handle legacy plugins
+    if (Plugin === 'base' || Plugin === 'default') {
+      return; // ignore plugins
+    }
+    if (Plugin === 'promises') {
+      // maps this.request -> this.doPromisesRequest
+      debug('Adding plugin promises...');
+      self._usePromises = true;
+      return;
+    }
+
+    if (typeof Plugin === 'string') {
+      Plugin = require('../plugins/' + Plugin);
+    }
+
+    debug(`Adding plugin '${Plugin.name}'...`);
+    self._plugins.push(new Plugin(self._client, self._opts));
+  });
+};
+
+/**
+ * Perform a request using this Cloudant client.
+ *
+ * @param {Object} options - HTTP options.
+ * @param {requestCallback} callback - The callback that handles the response.
+ */
+CloudantClient.prototype.request = function(options, callback) {
+  if (this._usePromises) {
+    // return a promise
+    return this._doPromisesRequest(options, callback);
+  } else {
+    return this._doRequest(options, callback);
+  }
+};
+
+module.exports = CloudantClient;

--- a/lib/clientutils.js
+++ b/lib/clientutils.js
@@ -1,0 +1,129 @@
+// Copyright © 2017 IBM Corp. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+'use strict';
+
+const async = require('async');
+
+// send response to the client
+var sendResponseToClient = function(response, clientStream, clientCallback) {
+  // response = [<error>, <response>, <data>]
+  if (response[0]) {
+    clientStream.emit('error', response[0]);
+  }
+  if (response[1]) {
+    clientStream.emit('response', response[1]);
+  }
+  if (response[2]) {
+    clientStream.emit('data', Buffer.from(response[2], 'utf8'));
+  }
+  clientStream.emit('end');
+
+  if (typeof clientCallback === 'function') {
+    clientCallback.apply(null, response); // execute client callback
+  }
+};
+
+// update the state with a new state (from plugin hook)
+var updateState = function(state, newState, callback) {
+  if (newState.abortWithResponse) {
+    // plugin requested immediate abort
+    state.retry = false;
+    state.abortWithResponse = newState.abortWithResponse;
+    return callback(new Error('Plugin issued abort')); // stop plugin hooks
+  }
+  if (newState.retry) {
+    state.retry = true; // plugin requested a retry
+  }
+  if (newState.retryDelay > state.retryDelay) {
+    state.retryDelay = newState.retryDelay; // set new retry delay
+  }
+  callback();
+};
+
+// public
+
+// process state (following plugin execution)
+var processState = function(r, callback) {
+  if (r.state.abortWithResponse) {
+    if (r.response) {
+      r.response.abort();
+    }
+    sendResponseToClient(r.state.abortWithResponse, r.clientStream, r.clientCallback);
+    var err = new Error('Plugin issued abort');
+    err.skipClientCallback = true;
+    callback(err); // no retry
+  } else if (!r.response) {
+    callback(); // running request hooks, continue
+  } else if (r.state.retry && r.state.attempt < r.state.maxAttempt) {
+    r.response.abort();
+    callback(); // retry request
+  } else {
+    r.state.retry = false; // => response ok || too many retries
+    if (r.eventPipe) {
+      r.eventPipe.resume(); // replay captured events
+    }
+    callback(new Error('No retry requested')); // no retry
+  }
+};
+
+// execute a specified hook for all plugins
+var runHooks = function(hookName, r, data, end) {
+  if (r.plugins.length === 0) {
+    end(); // no plugins
+  } else {
+    async.eachSeries(r.plugins, function(plugin, done) {
+      if (typeof plugin[hookName] !== 'function') {
+        done(); // no hooks for plugin
+      } else {
+        plugin[hookName](Object.assign({}, r.state), data, function(newState) {
+          updateState(r.state, newState, done);
+        });
+      }
+    }, end);
+  }
+};
+
+// wrap client callback to allow for plugin hook execution
+var wrapCallback = function(r, done) {
+  if (typeof r.clientCallback === 'undefined') {
+    return undefined; // noop - run hooks using response event listener
+  } else {
+    // return wrapped callback
+    return function(error, response, body) {
+      var cb = function() {
+        processState(r, function(stop) {
+          if (stop) {
+            if (!stop.skipClientCallback) {
+              r.clientCallback(error, response, body);
+            }
+            done(stop);
+          } else {
+            done();
+          }
+        });
+      };
+      if (error) {
+        runHooks('onError', r, error, cb);
+      } else {
+        runHooks('onResponse', r, response, cb);
+      }
+    };
+  }
+};
+
+module.exports = {
+  runHooks: runHooks,
+  processState: processState,
+  wrapCallback: wrapCallback
+};

--- a/plugins/base.js
+++ b/plugins/base.js
@@ -1,0 +1,27 @@
+// Copyright © 2017 IBM Corp. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+'use strict';
+
+/**
+ * Cloudant base plugin.
+ *
+ * @param {Object} client - HTTP client.
+ * @param {Object} opts - Plugin options.
+ */
+function BasePlugin(client, opts) {
+  this._client = client;
+  this._opts = opts;
+}
+
+module.exports = BasePlugin;

--- a/test/client.js
+++ b/test/client.js
@@ -1,0 +1,1608 @@
+// Copyright © 2017 IBM Corp. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/* global describe it before after */
+'use strict';
+
+const assert = require('assert');
+const Client = require('../lib/client.js');
+const nock = require('./nock.js');
+const testPlugin = require('./fixtures/testplugins.js');
+const uuidv4 = require('uuid/v4'); // random
+
+const ME = process.env.cloudant_username || 'nodejs';
+const PASSWORD = process.env.cloudant_password || 'sjedon';
+const SERVER = `https://${ME}.cloudant.com`;
+const DBNAME = `/nodejs-cloudant-${uuidv4()}`;
+
+describe('CloudantClient', function() {
+  before(function(done) {
+    var mocks = nock(SERVER)
+        .put(DBNAME)
+        .reply(201, {ok: true});
+
+    var cloudantClient = new Client();
+
+    var options = {
+      url: SERVER + DBNAME,
+      auth: { username: ME, password: PASSWORD },
+      method: 'PUT'
+    };
+    cloudantClient.request(options, function(err, resp) {
+      assert.equal(err, null);
+      assert.equal(resp.statusCode, 201);
+      mocks.done();
+      done();
+    });
+  });
+
+  after(function(done) {
+    var mocks = nock(SERVER)
+        .delete(DBNAME)
+        .reply(200, {ok: true});
+
+    var cloudantClient = new Client();
+
+    var options = {
+      url: SERVER + DBNAME,
+      auth: { username: ME, password: PASSWORD },
+      method: 'DELETE'
+    };
+    cloudantClient.request(options, function(err, resp) {
+      assert.equal(err, null);
+      assert.equal(resp.statusCode, 200);
+      mocks.done();
+      done();
+    });
+  });
+
+  describe('plugin support', function() {
+    it('allows plugins to be added seperately', function() {
+      var cloudantClient = new Client();
+      cloudantClient.addPlugins(testPlugin.NoopPlugin); // plugin 1
+      cloudantClient.addPlugins(testPlugin.NoopPlugin); // plugin 2
+      cloudantClient.addPlugins(testPlugin.NoopPlugin); // plugin 3
+      assert.equal(cloudantClient._plugins.length, 3);
+    });
+
+    it('allows an array of plugins to be added', function() {
+      var cloudantClient = new Client();
+      var plugins = [testPlugin.NoopPlugin, testPlugin.NoopPlugin, testPlugin.NoopPlugin];
+      cloudantClient.addPlugins(plugins);
+      assert.equal(cloudantClient._plugins.length, 3);
+    });
+
+    it('allows a single plugin to be added via "plugin" options', function() {
+      var cloudantClient = new Client({ plugin: ['cookieauth'] });
+      assert.equal(cloudantClient._plugins.length, 1);
+      assert.equal(cloudantClient._usePromises, false);
+    });
+
+    it('allows a single plugin to be added via "plugins" options', function() {
+      var cloudantClient = new Client({ plugins: ['cookieauth'] });
+      assert.equal(cloudantClient._plugins.length, 1);
+      assert.equal(cloudantClient._usePromises, false);
+    });
+
+    it('allows an array of plugins to be added via "plugin" options', function() {
+      var cloudantClient = new Client({
+        plugin: [
+          'promises', // sets cloudantClient._usePromises -> true
+          'retry', // plugin 1
+          'cookieauth', // plugin 2
+          'default', // ignored
+          'base' // ignored
+        ]
+      });
+      assert.equal(cloudantClient._plugins.length, 2);
+      assert.ok(cloudantClient._usePromises);
+    });
+
+    it('allows an array of plugins to be added via "plugins" options', function() {
+      var cloudantClient = new Client({
+        plugins: [
+          'promises', // sets cloudantClient._usePromises -> true
+          'retry', // plugin 1
+          'cookieauth', // plugin 2
+          'default', // ignored
+          'base' // ignored
+        ]
+      });
+      assert.equal(cloudantClient._plugins.length, 2);
+      assert.ok(cloudantClient._usePromises);
+    });
+  });
+
+  describe('using callbacks', function() {
+    describe('with no plugins', function() {
+      it('performs request and returns response', function(done) {
+        var mocks = nock(SERVER)
+            .get(DBNAME)
+            .reply(200, {doc_count: 0});
+
+        var cloudantClient = new Client();
+        assert.equal(cloudantClient._plugins.length, 0);
+
+        var options = {
+          url: SERVER + DBNAME,
+          auth: { username: ME, password: PASSWORD },
+          method: 'GET'
+        };
+        cloudantClient.request(options, function(err, resp, data) {
+          assert.equal(err, null);
+          assert.equal(resp.statusCode, 200);
+          assert.ok(data.indexOf('"doc_count":0') > -1);
+          mocks.done();
+          done();
+        });
+      });
+
+      it('performs request and returns error', function(done) {
+        if (process.env.NOCK_OFF) {
+          this.skip();
+        }
+
+        var mocks = nock(SERVER)
+            .get(DBNAME)
+            .replyWithError({code: 'ECONNRESET', message: 'socket hang up'});
+
+        var cloudantClient = new Client();
+        assert.equal(cloudantClient._plugins.length, 0);
+
+        var options = {
+          url: SERVER + DBNAME,
+          auth: { username: ME, password: PASSWORD },
+          method: 'GET'
+        };
+        cloudantClient.request(options, function(err, resp, data) {
+          assert.equal(err.code, 'ECONNRESET');
+          assert.equal(err.message, 'socket hang up');
+          mocks.done();
+          done();
+        });
+      });
+    });
+
+    describe('with single Noop plugin', function() {
+      it('performs request and calls request and response hooks only', function(done) {
+        var mocks = nock(SERVER)
+            .get(DBNAME)
+            .reply(200, {doc_count: 0});
+
+        var cloudantClient = new Client();
+        cloudantClient.addPlugins(testPlugin.NoopPlugin);
+        assert.equal(cloudantClient._plugins.length, 1);
+
+        var options = {
+          url: SERVER + DBNAME,
+          auth: { username: ME, password: PASSWORD },
+          method: 'GET'
+        };
+        cloudantClient.request(options, function(err, resp, data) {
+          assert.equal(err, null);
+          assert.equal(resp.statusCode, 200);
+          assert.ok(data.indexOf('"doc_count":0') > -1);
+
+          assert.equal(cloudantClient._plugins[0].onRequestCallCount, 1);
+          assert.equal(cloudantClient._plugins[0].onErrorCallCount, 0);
+          assert.equal(cloudantClient._plugins[0].onResponseCallCount, 1);
+
+          mocks.done();
+          done();
+        });
+      });
+
+      it('performs request and calls request and error hooks only', function(done) {
+        if (process.env.NOCK_OFF) {
+          this.skip();
+        }
+
+        var mocks = nock(SERVER)
+            .get(DBNAME)
+            .replyWithError({code: 'ECONNRESET', message: 'socket hang up'});
+
+        var cloudantClient = new Client();
+        cloudantClient.addPlugins(testPlugin.NoopPlugin);
+
+        var options = {
+          url: SERVER + DBNAME,
+          auth: { username: ME, password: PASSWORD },
+          method: 'GET'
+        };
+        cloudantClient.request(options, function(err, resp, data) {
+          assert.equal(err.code, 'ECONNRESET');
+          assert.equal(err.message, 'socket hang up');
+
+          assert.equal(cloudantClient._plugins[0].onRequestCallCount, 1);
+          assert.equal(cloudantClient._plugins[0].onErrorCallCount, 1);
+          assert.equal(cloudantClient._plugins[0].onResponseCallCount, 0);
+
+          mocks.done();
+          done();
+        });
+      });
+    });
+
+    describe('with multiple Noop plugins', function() {
+      it('performs request and calls request and response hooks only', function(done) {
+        var mocks = nock(SERVER)
+            .get(DBNAME)
+            .reply(200, {doc_count: 0});
+
+        var cloudantClient = new Client();
+        cloudantClient.addPlugins(testPlugin.NoopPlugin); // plugin 1
+        cloudantClient.addPlugins(testPlugin.NoopPlugin); // plugin 2
+        cloudantClient.addPlugins(testPlugin.NoopPlugin); // plugin 3
+        assert.equal(cloudantClient._plugins.length, 3);
+
+        var options = {
+          url: SERVER + DBNAME,
+          auth: { username: ME, password: PASSWORD },
+          method: 'GET'
+        };
+        cloudantClient.request(options, function(err, resp, data) {
+          assert.equal(err, null);
+          assert.equal(resp.statusCode, 200);
+          assert.ok(data.indexOf('"doc_count":0') > -1);
+
+          cloudantClient._plugins.forEach(function(plugin) {
+            assert.equal(plugin.onRequestCallCount, 1);
+            assert.equal(plugin.onErrorCallCount, 0);
+            assert.equal(plugin.onResponseCallCount, 1);
+          });
+
+          mocks.done();
+          done();
+        });
+      });
+
+      it('performs request and calls request and error hooks only', function(done) {
+        if (process.env.NOCK_OFF) {
+          this.skip();
+        }
+
+        var mocks = nock(SERVER)
+            .get(DBNAME)
+            .replyWithError({code: 'ECONNRESET', message: 'socket hang up'});
+
+        var cloudantClient = new Client();
+        cloudantClient.addPlugins(testPlugin.NoopPlugin); // plugin 1
+        cloudantClient.addPlugins(testPlugin.NoopPlugin); // plugin 2
+        cloudantClient.addPlugins(testPlugin.NoopPlugin); // plugin 3
+        assert.equal(cloudantClient._plugins.length, 3);
+
+        var options = {
+          url: SERVER + DBNAME,
+          auth: { username: ME, password: PASSWORD },
+          method: 'GET'
+        };
+        cloudantClient.request(options, function(err, resp, data) {
+          assert.equal(err.code, 'ECONNRESET');
+          assert.equal(err.message, 'socket hang up');
+
+          cloudantClient._plugins.forEach(function(plugin) {
+            assert.equal(plugin.onRequestCallCount, 1);
+            assert.equal(plugin.onErrorCallCount, 1);
+            assert.equal(plugin.onResponseCallCount, 0);
+          });
+
+          mocks.done();
+          done();
+        });
+      });
+    });
+
+    describe('with ComplexPlugin1 ', function() {
+      it('performs request and calls request and response hooks only', function(done) {
+        var mocks = nock(SERVER);
+        if (!process.env.NOCK_OFF) {
+          mocks
+            .put(DBNAME)
+            .times(10)
+            .reply(412, {
+              error: 'file_exists',
+              reason: 'The database could not be created, the file already exists.'
+            });
+        }
+
+        var cloudantClient = new Client({ maxAttempt: 10 });
+        cloudantClient.addPlugins(testPlugin.ComplexPlugin1);
+        assert.equal(cloudantClient._plugins.length, 1);
+
+        var options = {
+          url: SERVER + DBNAME,
+          auth: { username: ME, password: PASSWORD },
+          method: 'HEAD' // ComplexPlugin1 will set method to 'PUT'
+        };
+        var startTs = (new Date()).getTime();
+        cloudantClient.request(options, function(err, resp, data) {
+          assert.equal(err, null);
+          assert.equal(resp.statusCode, 412);
+          assert.ok(data.indexOf('"error":"file_exists"') > -1);
+          assert.equal(resp.request.headers.ComplexPlugin1, 'foo');
+
+          assert.equal(cloudantClient._plugins[0].onRequestCallCount, 10);
+          assert.equal(cloudantClient._plugins[0].onErrorCallCount, 0);
+          assert.equal(cloudantClient._plugins[0].onResponseCallCount, 10);
+
+          // validate retry delay
+          var now = (new Date()).getTime();
+          assert.ok(now - startTs > (10 + 20 + 40 + 80 + 160 + 320 + 640 + 1280 + 2560));
+
+          mocks.done();
+          done();
+        });
+      });
+
+      it('performs request and calls request and error hooks only', function(done) {
+        if (process.env.NOCK_OFF) {
+          this.skip();
+        }
+
+        var mocks = nock(SERVER)
+            .put(DBNAME).times(10)
+            .replyWithError({code: 'ECONNRESET', message: 'socket hang up'});
+
+        var cloudantClient = new Client({ maxAttempt: 10 });
+        cloudantClient.addPlugins(testPlugin.ComplexPlugin1);
+        assert.equal(cloudantClient._plugins.length, 1);
+
+        var options = {
+          url: SERVER + DBNAME,
+          auth: { username: ME, password: PASSWORD },
+          method: 'GET' // ComplexPlugin1 will set method to 'PUT'
+        };
+        cloudantClient.request(options, function(err, resp, data) {
+          assert.equal(err.code, 'ECONNRESET');
+          assert.equal(err.message, 'socket hang up');
+
+          assert.equal(cloudantClient._plugins[0].onRequestCallCount, 10);
+          assert.equal(cloudantClient._plugins[0].onErrorCallCount, 10);
+          assert.equal(cloudantClient._plugins[0].onResponseCallCount, 0);
+
+          mocks.done();
+          done();
+        });
+      });
+    });
+
+    describe('with ComplexPlugin2', function() {
+      it('performs request and calls request and response hooks only', function(done) {
+        if (process.env.NOCK_OFF) {
+          this.skip();
+        }
+
+        var mocks = nock(SERVER)
+          .get(DBNAME)
+          .times(2)
+          .reply(401, {
+            error: 'unauthorized',
+            reason: '_reader access is required for this request'
+          });
+
+        var cloudantClient = new Client({ maxAttempt: 10 });
+        cloudantClient.addPlugins(testPlugin.ComplexPlugin2);
+        assert.equal(cloudantClient._plugins.length, 1);
+
+        var options = {
+          url: SERVER + DBNAME,
+          auth: { username: ME, password: PASSWORD },
+          method: 'POST' // ComplexPlugin2 will set method to 'GET'
+        };
+        cloudantClient.request(options, function(err, resp, data) {
+          assert.equal(err, null);
+          assert.equal(resp.statusCode, 401);
+          assert.ok(data.indexOf('"error":"unauthorized"') > -1);
+          assert.equal(resp.request.headers.ComplexPlugin2, 'bar');
+
+          assert.equal(cloudantClient._plugins[0].onRequestCallCount, 2);
+          assert.equal(cloudantClient._plugins[0].onErrorCallCount, 0);
+          assert.equal(cloudantClient._plugins[0].onResponseCallCount, 2);
+
+          mocks.done();
+          done();
+        });
+      });
+
+      it('performs request and calls request and error hooks only', function(done) {
+        if (process.env.NOCK_OFF) {
+          this.skip();
+        }
+
+        var mocks = nock(SERVER)
+            .get(DBNAME)
+            .replyWithError({code: 'ECONNRESET', message: 'socket hang up'})
+            .get('/bar')
+            .reply(200, {ok: true});
+
+        var cloudantClient = new Client({ maxAttempt: 10 });
+        cloudantClient.addPlugins(testPlugin.ComplexPlugin2);
+        assert.equal(cloudantClient._plugins.length, 1);
+
+        var options = {
+          url: SERVER + DBNAME,
+          auth: { username: ME, password: PASSWORD },
+          method: 'DELETE' // ComplexPlugin2 will set method to 'GET'
+        };
+        cloudantClient.request(options, function(err, resp, data) {
+          assert.equal(err, null);
+          assert.equal(resp.statusCode, 200);
+          assert.ok(data.indexOf('"ok":true') > -1);
+
+          assert.equal(cloudantClient._plugins[0].onRequestCallCount, 1);
+          assert.equal(cloudantClient._plugins[0].onErrorCallCount, 1);
+          assert.equal(cloudantClient._plugins[0].onResponseCallCount, 0);
+
+          mocks.done();
+          done();
+        });
+      });
+    });
+
+    describe('with ComplexPlugin3', function() {
+      it('performs request and calls request and response hooks only', function(done) {
+        if (process.env.NOCK_OFF) {
+          this.skip();
+        }
+
+        var mocks = nock(SERVER)
+          .get(DBNAME)
+          .times(2)
+          .reply(500, {
+            error: 'internal_server_error',
+            reason: 'Internal Server Error'
+          })
+          .delete('/bar')
+          .reply(200, {ok: true});
+
+        var cloudantClient = new Client({ maxAttempt: 10 });
+        cloudantClient.addPlugins(testPlugin.ComplexPlugin3);
+        assert.equal(cloudantClient._plugins.length, 1);
+
+        var options = {
+          url: SERVER + DBNAME,
+          auth: { username: ME, password: PASSWORD },
+          method: 'GET'
+        };
+        cloudantClient.request(options, function(err, resp, data) {
+          assert.equal(err, null);
+          assert.equal(resp.statusCode, 200);
+          assert.ok(data.indexOf('"ok":true') > -1);
+
+          assert.equal(cloudantClient._plugins[0].onResponseCallCount, 2);
+
+          mocks.done();
+          done();
+        });
+      });
+
+      it('performs request and calls request and error hooks only', function(done) {
+        if (process.env.NOCK_OFF) {
+          this.skip();
+        }
+
+        var mocks = nock(SERVER)
+            .get(DBNAME)
+            .replyWithError({code: 'ECONNRESET', message: 'socket hang up'});
+
+        var cloudantClient = new Client({ maxAttempt: 10 });
+        cloudantClient.addPlugins(testPlugin.ComplexPlugin3);
+        assert.equal(cloudantClient._plugins.length, 1);
+
+        var options = {
+          url: SERVER + DBNAME,
+          auth: { username: ME, password: PASSWORD },
+          method: 'GET'
+        };
+        cloudantClient.request(options, function(err, resp, data) {
+          assert.equal(err.code, 'ECONNRESET');
+          assert.equal(err.message, 'socket hang up');
+
+          assert.equal(cloudantClient._plugins[0].onResponseCallCount, 0);
+
+          mocks.done();
+          done();
+        });
+      });
+    });
+
+    describe('with multiple plugins', function() {
+      it('performs request and calls all response hooks', function(done) {
+        var mocks = nock(SERVER);
+        if (!process.env.NOCK_OFF) {
+          mocks
+            .get(DBNAME).times(3)
+            .reply(200, {doc_count: 0});
+        }
+
+        var cloudantClient = new Client({ maxAttempt: 3 });
+        cloudantClient.addPlugins([
+          testPlugin.PluginA,
+          testPlugin.PluginB,
+          testPlugin.PluginC,
+          testPlugin.PluginD
+        ]);
+
+        var options = {
+          url: SERVER + DBNAME,
+          auth: { username: ME, password: PASSWORD },
+          method: 'GET'
+        };
+        cloudantClient.request(options, function(err, resp, data) {
+          assert.equal(err, null);
+          assert.equal(resp.statusCode, 200);
+          assert.ok(data.indexOf('"doc_count":0') > -1);
+
+          mocks.done();
+          done();
+        });
+      });
+
+      it('performs request and calls all error hooks', function(done) {
+        if (process.env.NOCK_OFF) {
+          this.skip();
+        }
+
+        var mocks = nock(SERVER)
+          .get(DBNAME).times(3)
+          .replyWithError({code: 'ECONNRESET', message: 'socket hang up'});
+
+        var cloudantClient = new Client({ maxAttempt: 3 });
+        cloudantClient.addPlugins([
+          testPlugin.PluginA,
+          testPlugin.PluginB,
+          testPlugin.PluginC,
+          testPlugin.PluginD
+        ]);
+
+        var options = {
+          url: SERVER + DBNAME,
+          auth: { username: ME, password: PASSWORD },
+          method: 'GET'
+        };
+        cloudantClient.request(options, function(err, resp, data) {
+          assert.equal(err.code, 'ECONNRESET');
+          assert.equal(err.message, 'socket hang up');
+
+          mocks.done();
+          done();
+        });
+      });
+    });
+  });
+
+  describe('using listeners', function() {
+    describe('with no plugins', function() {
+      it('performs request and returns response', function(done) {
+        var mocks = nock(SERVER)
+            .get(DBNAME)
+            .reply(200, {doc_count: 0});
+
+        var cloudantClient = new Client();
+        assert.equal(cloudantClient._plugins.length, 0);
+
+        var options = {
+          url: SERVER + DBNAME,
+          auth: { username: ME, password: PASSWORD },
+          method: 'GET'
+        };
+        cloudantClient.request(options)
+          .on('error', function(err) {
+            assert.fail(`Unexpected error: ${err}`);
+          })
+          .on('response', function(resp) {
+            assert.equal(resp.statusCode, 200);
+          })
+          .on('data', function(data) {
+            assert.ok(data.toString('utf8').indexOf('"doc_count":0') > -1);
+          })
+          .on('end', function() {
+            mocks.done();
+            done();
+          });
+      });
+
+      it('performs request and returns error', function(done) {
+        if (process.env.NOCK_OFF) {
+          this.skip();
+        }
+
+        var mocks = nock(SERVER)
+            .get(DBNAME)
+            .replyWithError({code: 'ECONNRESET', message: 'socket hang up'});
+
+        var cloudantClient = new Client();
+        assert.equal(cloudantClient._plugins.length, 0);
+
+        var options = {
+          url: SERVER + DBNAME,
+          auth: { username: ME, password: PASSWORD },
+          method: 'GET'
+        };
+        cloudantClient.request(options)
+          .on('error', function(err) {
+            assert.equal(err.code, 'ECONNRESET');
+            assert.equal(err.message, 'socket hang up');
+            mocks.done();
+            done();
+          });
+      });
+    });
+
+    describe('with single Noop plugin', function() {
+      it('performs request and calls request and response hooks only', function(done) {
+        var mocks = nock(SERVER)
+            .get(DBNAME)
+            .reply(200, {doc_count: 0});
+
+        var cloudantClient = new Client();
+        cloudantClient.addPlugins(testPlugin.NoopPlugin);
+        assert.equal(cloudantClient._plugins.length, 1);
+
+        var options = {
+          url: SERVER + DBNAME,
+          auth: { username: ME, password: PASSWORD },
+          method: 'GET'
+        };
+        cloudantClient.request(options)
+          .on('error', function(err) {
+            assert.fail(`Unexpected error: ${err}`);
+          })
+          .on('response', function(resp) {
+            assert.equal(resp.statusCode, 200);
+          })
+          .on('data', function(data) {
+            assert.ok(data.toString('utf8').indexOf('"doc_count":0') > -1);
+          })
+          .on('end', function() {
+            assert.equal(cloudantClient._plugins[0].onRequestCallCount, 1);
+            assert.equal(cloudantClient._plugins[0].onErrorCallCount, 0);
+            assert.equal(cloudantClient._plugins[0].onResponseCallCount, 1);
+            mocks.done();
+            done();
+          });
+      });
+
+      it('performs request and calls request and error hooks only', function(done) {
+        if (process.env.NOCK_OFF) {
+          this.skip();
+        }
+
+        var mocks = nock(SERVER)
+            .get(DBNAME)
+            .replyWithError({code: 'ECONNRESET', message: 'socket hang up'});
+
+        var cloudantClient = new Client();
+        cloudantClient.addPlugins(testPlugin.NoopPlugin);
+
+        var options = {
+          url: SERVER + DBNAME,
+          auth: { username: ME, password: PASSWORD },
+          method: 'GET'
+        };
+        cloudantClient.request(options)
+          .on('error', function(err) {
+            assert.equal(err.code, 'ECONNRESET');
+            assert.equal(err.message, 'socket hang up');
+
+            assert.equal(cloudantClient._plugins[0].onRequestCallCount, 1);
+            assert.equal(cloudantClient._plugins[0].onErrorCallCount, 1);
+            assert.equal(cloudantClient._plugins[0].onResponseCallCount, 0);
+
+            mocks.done();
+            done();
+          });
+      });
+    });
+
+    describe('with multiple Noop plugins', function() {
+      it('performs request and calls request and response hooks only', function(done) {
+        var mocks = nock(SERVER)
+            .get(DBNAME)
+            .reply(200, {doc_count: 0});
+
+        var cloudantClient = new Client();
+        cloudantClient.addPlugins(testPlugin.NoopPlugin); // plugin 1
+        cloudantClient.addPlugins(testPlugin.NoopPlugin); // plugin 2
+        cloudantClient.addPlugins(testPlugin.NoopPlugin); // plugin 3
+        assert.equal(cloudantClient._plugins.length, 3);
+
+        var options = {
+          url: SERVER + DBNAME,
+          auth: { username: ME, password: PASSWORD },
+          method: 'GET'
+        };
+        cloudantClient.request(options)
+          .on('error', function(err) {
+            assert.fail(`Unexpected error: ${err}`);
+          })
+          .on('response', function(resp) {
+            assert.equal(resp.statusCode, 200);
+          })
+          .on('data', function(data) {
+            assert.ok(data.toString('utf8').indexOf('"doc_count":0') > -1);
+          })
+          .on('end', function() {
+            assert.equal(cloudantClient._plugins[0].onRequestCallCount, 1);
+            assert.equal(cloudantClient._plugins[0].onErrorCallCount, 0);
+            assert.equal(cloudantClient._plugins[0].onResponseCallCount, 1);
+            mocks.done();
+            done();
+          });
+      });
+
+      it('performs request and calls request and error hooks only', function(done) {
+        if (process.env.NOCK_OFF) {
+          this.skip();
+        }
+
+        var mocks = nock(SERVER)
+            .get(DBNAME)
+            .replyWithError({code: 'ECONNRESET', message: 'socket hang up'});
+
+        var cloudantClient = new Client();
+        cloudantClient.addPlugins(testPlugin.NoopPlugin); // plugin 1
+        cloudantClient.addPlugins(testPlugin.NoopPlugin); // plugin 2
+        cloudantClient.addPlugins(testPlugin.NoopPlugin); // plugin 3
+        assert.equal(cloudantClient._plugins.length, 3);
+
+        var options = {
+          url: SERVER + DBNAME,
+          auth: { username: ME, password: PASSWORD },
+          method: 'GET'
+        };
+        cloudantClient.request(options)
+          .on('error', function(err) {
+            assert.equal(err.code, 'ECONNRESET');
+            assert.equal(err.message, 'socket hang up');
+
+            cloudantClient._plugins.forEach(function(plugin) {
+              assert.equal(plugin.onRequestCallCount, 1);
+              assert.equal(plugin.onErrorCallCount, 1);
+              assert.equal(plugin.onResponseCallCount, 0);
+            });
+
+            mocks.done();
+            done();
+          });
+      });
+    });
+
+    describe('with ComplexPlugin1', function() {
+      it('performs request and calls request and response hooks only', function(done) {
+        var mocks = nock(SERVER);
+        if (!process.env.NOCK_OFF) {
+          mocks
+            .put(DBNAME)
+            .times(10)
+            .reply(412, {
+              error: 'file_exists',
+              reason: 'The database could not be created, the file already exists.'
+            });
+        }
+
+        var cloudantClient = new Client({ maxAttempt: 10 });
+        cloudantClient.addPlugins(testPlugin.ComplexPlugin1);
+        assert.equal(cloudantClient._plugins.length, 1);
+
+        var options = {
+          url: SERVER + DBNAME,
+          auth: { username: ME, password: PASSWORD },
+          method: 'HEAD' // ComplexPlugin1 will set method to 'PUT'
+        };
+        var startTs = (new Date()).getTime();
+        cloudantClient.request(options)
+          .on('error', function(err) {
+            assert.fail(`Unexpected error: ${err}`);
+          })
+          .on('response', function(resp) {
+            assert.equal(resp.statusCode, 412);
+            assert.equal(resp.request.headers.ComplexPlugin1, 'foo');
+          })
+          .on('data', function(data) {
+            assert.ok(data.toString('utf8').indexOf('"error":"file_exists"') > -1);
+          })
+          .on('end', function() {
+            assert.equal(cloudantClient._plugins[0].onRequestCallCount, 10);
+            assert.equal(cloudantClient._plugins[0].onErrorCallCount, 0);
+            assert.equal(cloudantClient._plugins[0].onResponseCallCount, 10);
+
+            // validate retry delay
+            var now = (new Date()).getTime();
+            assert.ok(now - startTs > (10 + 20 + 40 + 80 + 160 + 320 + 640 + 1280 + 2560));
+
+            mocks.done();
+            done();
+          });
+      });
+
+      it('performs request and calls request and error hooks only', function(done) {
+        if (process.env.NOCK_OFF) {
+          this.skip();
+        }
+
+        var mocks = nock(SERVER)
+            .put(DBNAME).times(10)
+            .replyWithError({code: 'ECONNRESET', message: 'socket hang up'});
+
+        var cloudantClient = new Client({ maxAttempt: 10 });
+        cloudantClient.addPlugins(testPlugin.ComplexPlugin1);
+        assert.equal(cloudantClient._plugins.length, 1);
+
+        var options = {
+          url: SERVER + DBNAME,
+          auth: { username: ME, password: PASSWORD },
+          method: 'GET' // ComplexPlugin1 will set method to 'PUT'
+        };
+        cloudantClient.request(options)
+          .on('error', function(err) {
+            assert.equal(err.code, 'ECONNRESET');
+            assert.equal(err.message, 'socket hang up');
+
+            assert.equal(cloudantClient._plugins[0].onRequestCallCount, 10);
+            assert.equal(cloudantClient._plugins[0].onErrorCallCount, 10);
+            assert.equal(cloudantClient._plugins[0].onResponseCallCount, 0);
+
+            mocks.done();
+            done();
+          });
+      });
+    });
+
+    describe('with ComplexPlugin2', function() {
+      it('performs request and calls request and response hooks only', function(done) {
+        if (process.env.NOCK_OFF) {
+          this.skip();
+        }
+
+        var mocks = nock(SERVER)
+          .get(DBNAME)
+          .times(2)
+          .reply(401, {
+            error: 'unauthorized',
+            reason: '_reader access is required for this request'
+          });
+
+        var cloudantClient = new Client({ maxAttempt: 10 });
+        cloudantClient.addPlugins(testPlugin.ComplexPlugin2);
+        assert.equal(cloudantClient._plugins.length, 1);
+
+        var options = {
+          url: SERVER + DBNAME,
+          auth: { username: ME, password: PASSWORD },
+          method: 'POST' // ComplexPlugin2 will set method to 'GET'
+        };
+        cloudantClient.request(options)
+          .on('error', function(err) {
+            assert.fail(`Unexpected error: ${err}`);
+          })
+          .on('response', function(resp) {
+            assert.equal(resp.statusCode, 401);
+            assert.equal(resp.request.headers.ComplexPlugin2, 'bar');
+          })
+          .on('data', function(data) {
+            assert.ok(data.toString('utf8').indexOf('"error":"unauthorized"') > -1);
+          })
+          .on('end', function() {
+            assert.equal(cloudantClient._plugins[0].onRequestCallCount, 2);
+            assert.equal(cloudantClient._plugins[0].onErrorCallCount, 0);
+            assert.equal(cloudantClient._plugins[0].onResponseCallCount, 2);
+
+            mocks.done();
+            done();
+          });
+      });
+
+      it('performs request and calls request and error hooks only', function(done) {
+        if (process.env.NOCK_OFF) {
+          this.skip();
+        }
+
+        var mocks = nock(SERVER)
+            .get(DBNAME)
+            .replyWithError({code: 'ECONNRESET', message: 'socket hang up'})
+            .get('/bar')
+            .reply(200, {ok: true});
+
+        var cloudantClient = new Client({ maxAttempt: 10 });
+        cloudantClient.addPlugins(testPlugin.ComplexPlugin2);
+        assert.equal(cloudantClient._plugins.length, 1);
+
+        var options = {
+          url: SERVER + DBNAME,
+          auth: { username: ME, password: PASSWORD },
+          method: 'DELETE' // ComplexPlugin2 will set method to 'GET'
+        };
+        cloudantClient.request(options)
+          .on('error', function(err) {
+            assert.fail(`Unexpected error: ${err}`);
+          })
+          .on('response', function(resp) {
+            assert.equal(resp.statusCode, 200);
+          })
+          .on('data', function(data) {
+            assert.ok(data.toString('utf8').indexOf('"ok":true') > -1);
+          })
+          .on('end', function() {
+            assert.equal(cloudantClient._plugins[0].onRequestCallCount, 1);
+            assert.equal(cloudantClient._plugins[0].onErrorCallCount, 1);
+            assert.equal(cloudantClient._plugins[0].onResponseCallCount, 0);
+            mocks.done();
+            done();
+          });
+      });
+    });
+
+    describe('with ComplexPlugin3', function() {
+      it('performs request and calls request and response hooks only', function(done) {
+        if (process.env.NOCK_OFF) {
+          this.skip();
+        }
+
+        var mocks = nock(SERVER)
+          .get(DBNAME)
+          .times(2)
+          .reply(500, {
+            error: 'internal_server_error',
+            reason: 'Internal Server Error'
+          })
+          .delete('/bar')
+          .reply(200, {ok: true});
+
+        var cloudantClient = new Client({ maxAttempt: 10 });
+        cloudantClient.addPlugins(testPlugin.ComplexPlugin3);
+        assert.equal(cloudantClient._plugins.length, 1);
+
+        var options = {
+          url: SERVER + DBNAME,
+          auth: { username: ME, password: PASSWORD },
+          method: 'GET'
+        };
+        cloudantClient.request(options)
+          .on('error', function(err) {
+            assert.fail(`Unexpected error: ${err}`);
+          })
+          .on('response', function(resp) {
+            assert.equal(resp.statusCode, 200);
+          })
+          .on('data', function(data) {
+            assert.ok(data.toString('utf8').indexOf('"ok":true') > -1);
+          })
+          .on('end', function() {
+            assert.equal(cloudantClient._plugins[0].onResponseCallCount, 2);
+            mocks.done();
+            done();
+          });
+      });
+
+      it('performs request and calls request and error hooks only', function(done) {
+        if (process.env.NOCK_OFF) {
+          this.skip();
+        }
+
+        var mocks = nock(SERVER)
+            .get(DBNAME)
+            .replyWithError({code: 'ECONNRESET', message: 'socket hang up'});
+
+        var cloudantClient = new Client({ maxAttempt: 10 });
+        cloudantClient.addPlugins(testPlugin.ComplexPlugin3);
+        assert.equal(cloudantClient._plugins.length, 1);
+
+        var options = {
+          url: SERVER + DBNAME,
+          auth: { username: ME, password: PASSWORD },
+          method: 'GET'
+        };
+        cloudantClient.request(options)
+          .on('error', function(err) {
+            assert.equal(err.code, 'ECONNRESET');
+            assert.equal(err.message, 'socket hang up');
+
+            assert.equal(cloudantClient._plugins[0].onResponseCallCount, 0);
+
+            mocks.done();
+            done();
+          });
+      });
+    });
+
+    describe('with multiple plugins', function() {
+      it('performs request and calls all response hooks', function(done) {
+        var mocks = nock(SERVER);
+        if (!process.env.NOCK_OFF) {
+          mocks
+            .get(DBNAME).times(3)
+            .reply(200, {doc_count: 0});
+        }
+
+        var cloudantClient = new Client({ maxAttempt: 3 });
+        cloudantClient.addPlugins([
+          testPlugin.PluginA,
+          testPlugin.PluginB,
+          testPlugin.PluginC,
+          testPlugin.PluginD
+        ]);
+
+        var options = {
+          url: SERVER + DBNAME,
+          auth: { username: ME, password: PASSWORD },
+          method: 'GET'
+        };
+        cloudantClient.request(options)
+          .on('error', function(err) {
+            assert.fail(`Unexpected error: ${err}`);
+          })
+          .on('response', function(resp) {
+            assert.equal(resp.statusCode, 200);
+          })
+          .on('data', function(data) {
+            assert.ok(data.toString('utf8').indexOf('"doc_count":0') > -1);
+          })
+          .on('end', function() {
+            mocks.done();
+            done();
+          });
+      });
+
+      it('performs request and calls all error hooks', function(done) {
+        if (process.env.NOCK_OFF) {
+          this.skip();
+        }
+
+        var mocks = nock(SERVER)
+          .get(DBNAME).times(3)
+          .replyWithError({code: 'ECONNRESET', message: 'socket hang up'});
+
+        var cloudantClient = new Client({ maxAttempt: 3 });
+        cloudantClient.addPlugins([
+          testPlugin.PluginA,
+          testPlugin.PluginB,
+          testPlugin.PluginC,
+          testPlugin.PluginD
+        ]);
+
+        var options = {
+          url: SERVER + DBNAME,
+          auth: { username: ME, password: PASSWORD },
+          method: 'GET'
+        };
+        cloudantClient.request(options)
+          .on('error', function(err) {
+            assert.equal(err.code, 'ECONNRESET');
+            assert.equal(err.message, 'socket hang up');
+
+            mocks.done();
+            done();
+          });
+      });
+    });
+  });
+
+  describe('using promises', function() {
+    describe('with no other plugins', function() {
+      it('performs request and returns response', function(done) {
+        var mocks = nock(SERVER)
+            .get(DBNAME)
+            .reply(200, {doc_count: 0});
+
+        var cloudantClient = new Client({ plugin: 'promises' });
+        assert.equal(cloudantClient._plugins.length, 0);
+        assert.ok(cloudantClient._usePromises);
+
+        var options = {
+          url: SERVER + DBNAME,
+          auth: { username: ME, password: PASSWORD },
+          method: 'GET'
+        };
+        var p = cloudantClient.request(options).then(function(data) {
+          assert.equal(data.doc_count, 0);
+          mocks.done();
+          done();
+        }).catch(function(err) {
+          assert.fail(`Unexpected reject: ${err}`);
+        });
+        assert.ok(p instanceof Promise);
+      });
+
+      it('performs request and returns error', function(done) {
+        if (process.env.NOCK_OFF) {
+          this.skip();
+        }
+
+        var mocks = nock(SERVER)
+            .get(DBNAME)
+            .replyWithError({code: 'ECONNRESET', message: 'socket hang up'});
+
+        var cloudantClient = new Client({ plugin: 'promises' });
+        assert.equal(cloudantClient._plugins.length, 0);
+        assert.ok(cloudantClient._usePromises);
+
+        var options = {
+          url: SERVER + DBNAME,
+          auth: { username: ME, password: PASSWORD },
+          method: 'GET'
+        };
+        var p = cloudantClient.request(options).then(function(data) {
+          assert.fail(`Unexpected resolve: ${data}`);
+        }).catch(function(err) {
+          assert.equal(err.code, 'ECONNRESET');
+          assert.equal(err.message, 'socket hang up');
+          mocks.done();
+          done();
+        });
+        assert.ok(p instanceof Promise);
+      });
+    });
+
+    describe('with single Noop plugin', function() {
+      it('performs request and calls request and response hooks only', function(done) {
+        var mocks = nock(SERVER)
+            .get(DBNAME)
+            .reply(200, {doc_count: 0});
+
+        var cloudantClient = new Client({ plugins: ['promises', testPlugin.NoopPlugin] });
+        assert.equal(cloudantClient._plugins.length, 1);
+        assert.ok(cloudantClient._usePromises);
+
+        var options = {
+          url: SERVER + DBNAME,
+          auth: { username: ME, password: PASSWORD },
+          method: 'GET'
+        };
+        var p = cloudantClient.request(options).then(function(data) {
+          assert.equal(data.doc_count, 0);
+
+          assert.equal(cloudantClient._plugins[0].onRequestCallCount, 1);
+          assert.equal(cloudantClient._plugins[0].onErrorCallCount, 0);
+          assert.equal(cloudantClient._plugins[0].onResponseCallCount, 1);
+
+          mocks.done();
+          done();
+        }).catch(function(err) {
+          assert.fail(`Unexpected reject: ${err}`);
+        });
+        assert.ok(p instanceof Promise);
+      });
+
+      it('performs request and calls request and error hooks only', function(done) {
+        if (process.env.NOCK_OFF) {
+          this.skip();
+        }
+
+        var mocks = nock(SERVER)
+            .get(DBNAME)
+            .replyWithError({code: 'ECONNRESET', message: 'socket hang up'});
+
+        var cloudantClient = new Client({ plugins: ['promises', testPlugin.NoopPlugin] });
+        assert.equal(cloudantClient._plugins.length, 1);
+        assert.ok(cloudantClient._usePromises);
+
+        var options = {
+          url: SERVER + DBNAME,
+          auth: { username: ME, password: PASSWORD },
+          method: 'GET'
+        };
+        var p = cloudantClient.request(options).then(function(data) {
+          assert.fail(`Unexpected resolve: ${data}`);
+        }).catch(function(err) {
+          assert.equal(err.code, 'ECONNRESET');
+          assert.equal(err.message, 'socket hang up');
+
+          assert.equal(cloudantClient._plugins[0].onRequestCallCount, 1);
+          assert.equal(cloudantClient._plugins[0].onErrorCallCount, 1);
+          assert.equal(cloudantClient._plugins[0].onResponseCallCount, 0);
+
+          mocks.done();
+          done();
+        });
+        assert.ok(p instanceof Promise);
+      });
+    });
+
+    describe('with multiple Noop plugins', function() {
+      it('performs request and calls request and response hooks only', function(done) {
+        var mocks = nock(SERVER)
+            .get(DBNAME)
+            .reply(200, {doc_count: 0});
+
+        var cloudantClient = new Client({ plugins: [
+          'promises',
+          testPlugin.NoopPlugin, // plugin 1
+          testPlugin.NoopPlugin, // plugin 2
+          testPlugin.NoopPlugin  // plugin 3
+        ]});
+        assert.equal(cloudantClient._plugins.length, 3);
+        assert.ok(cloudantClient._usePromises);
+
+        var options = {
+          url: SERVER + DBNAME,
+          auth: { username: ME, password: PASSWORD },
+          method: 'GET'
+        };
+        var p = cloudantClient.request(options).then(function(data) {
+          assert.equal(data.doc_count, 0);
+
+          cloudantClient._plugins.forEach(function(plugin) {
+            assert.equal(plugin.onRequestCallCount, 1);
+            assert.equal(plugin.onErrorCallCount, 0);
+            assert.equal(plugin.onResponseCallCount, 1);
+          });
+
+          mocks.done();
+          done();
+        }).catch(function(err) {
+          assert.fail(`Unexpected reject: ${err}`);
+        });
+        assert.ok(p instanceof Promise);
+      });
+
+      it('performs request and calls request and error hooks only', function(done) {
+        if (process.env.NOCK_OFF) {
+          this.skip();
+        }
+
+        var mocks = nock(SERVER)
+            .get(DBNAME)
+            .replyWithError({code: 'ECONNRESET', message: 'socket hang up'});
+
+        var cloudantClient = new Client({plugins: [
+          'promises',
+          testPlugin.NoopPlugin, // plugin 1
+          testPlugin.NoopPlugin, // plugin 2
+          testPlugin.NoopPlugin  // plugin 3
+        ]});
+        assert.equal(cloudantClient._plugins.length, 3);
+        assert.ok(cloudantClient._usePromises);
+
+        var options = {
+          url: SERVER + DBNAME,
+          auth: { username: ME, password: PASSWORD },
+          method: 'GET'
+        };
+        var p = cloudantClient.request(options).then(function(data) {
+          assert.fail(`Unexpected resolve: ${data}`);
+        }).catch(function(err) {
+          assert.equal(err.code, 'ECONNRESET');
+          assert.equal(err.message, 'socket hang up');
+
+          cloudantClient._plugins.forEach(function(plugin) {
+            assert.equal(plugin.onRequestCallCount, 1);
+            assert.equal(plugin.onErrorCallCount, 1);
+            assert.equal(plugin.onResponseCallCount, 0);
+          });
+
+          mocks.done();
+          done();
+        });
+        assert.ok(p instanceof Promise);
+      });
+    });
+
+    describe('with ComplexPlugin1 ', function() {
+      it('performs request and calls request and response hooks only', function(done) {
+        var mocks = nock(SERVER);
+        if (!process.env.NOCK_OFF) {
+          mocks
+            .put(DBNAME)
+            .times(10)
+            .reply(412, {
+              error: 'file_exists',
+              reason: 'The database could not be created, the file already exists.'
+            });
+        }
+
+        var cloudantClient = new Client({
+          maxAttempt: 10,
+          plugins: ['promises', testPlugin.ComplexPlugin1]
+        });
+        assert.equal(cloudantClient._plugins.length, 1);
+        assert.ok(cloudantClient._usePromises);
+
+        var options = {
+          url: SERVER + DBNAME,
+          auth: { username: ME, password: PASSWORD },
+          method: 'HEAD' // ComplexPlugin1 will set method to 'PUT'
+        };
+        var startTs = (new Date()).getTime();
+        var p = cloudantClient.request(options).then(function(data) {
+          assert.fail(`Unexpected resolve: ${data}`);
+        }).catch(function(err) {
+          assert.equal(err.statusCode, 412);
+          assert.equal(err.error, 'file_exists');
+          assert.equal(err.reason, 'The database could not be created, the file already exists.');
+
+          assert.equal(cloudantClient._plugins[0].onRequestCallCount, 10);
+          assert.equal(cloudantClient._plugins[0].onErrorCallCount, 0);
+          assert.equal(cloudantClient._plugins[0].onResponseCallCount, 10);
+
+          // validate retry delay
+          var now = (new Date()).getTime();
+          assert.ok(now - startTs > (10 + 20 + 40 + 80 + 160 + 320 + 640 + 1280 + 2560));
+
+          mocks.done();
+          done();
+        });
+        assert.ok(p instanceof Promise);
+      });
+
+      it('performs request and calls request and error hooks only', function(done) {
+        if (process.env.NOCK_OFF) {
+          this.skip();
+        }
+
+        var mocks = nock(SERVER)
+            .put(DBNAME).times(10)
+            .replyWithError({code: 'ECONNRESET', message: 'socket hang up'});
+
+        var cloudantClient = new Client({
+          maxAttempt: 10,
+          plugins: ['promises', testPlugin.ComplexPlugin1]
+        });
+        assert.equal(cloudantClient._plugins.length, 1);
+        assert.ok(cloudantClient._usePromises);
+
+        var options = {
+          url: SERVER + DBNAME,
+          auth: { username: ME, password: PASSWORD },
+          method: 'GET' // ComplexPlugin1 will set method to 'PUT'
+        };
+        var p = cloudantClient.request(options).then(function(data) {
+          assert.fail(`Unexpected resolve: ${data}`);
+        }).catch(function(err) {
+          assert.equal(err.code, 'ECONNRESET');
+          assert.equal(err.message, 'socket hang up');
+
+          assert.equal(cloudantClient._plugins[0].onRequestCallCount, 10);
+          assert.equal(cloudantClient._plugins[0].onErrorCallCount, 10);
+          assert.equal(cloudantClient._plugins[0].onResponseCallCount, 0);
+
+          mocks.done();
+          done();
+        });
+        assert.ok(p instanceof Promise);
+      });
+    });
+
+    describe('with ComplexPlugin2', function() {
+      it('performs request and calls request and response hooks only', function(done) {
+        if (process.env.NOCK_OFF) {
+          this.skip();
+        }
+
+        var mocks = nock(SERVER)
+          .get(DBNAME)
+          .times(2)
+          .reply(401, {
+            error: 'unauthorized',
+            reason: '_reader access is required for this request'
+          });
+
+        var cloudantClient = new Client({
+          maxAttempt: 10,
+          plugins: ['promises', testPlugin.ComplexPlugin2]
+        });
+        assert.equal(cloudantClient._plugins.length, 1);
+        assert.ok(cloudantClient._usePromises);
+
+        var options = {
+          url: SERVER + DBNAME,
+          auth: { username: ME, password: PASSWORD },
+          method: 'POST' // ComplexPlugin2 will set method to 'GET'
+        };
+        var p = cloudantClient.request(options).then(function(data) {
+          assert.fail(`Unexpected resolve: ${data}`);
+        }).catch(function(err) {
+          assert.equal(err.statusCode, 401);
+          assert.equal(err.error, 'unauthorized');
+          assert.equal(err.reason, '_reader access is required for this request');
+
+          assert.equal(cloudantClient._plugins[0].onRequestCallCount, 2);
+          assert.equal(cloudantClient._plugins[0].onErrorCallCount, 0);
+          assert.equal(cloudantClient._plugins[0].onResponseCallCount, 2);
+
+          mocks.done();
+          done();
+        });
+        assert.ok(p instanceof Promise);
+      });
+
+      it('performs request and calls request and error hooks only', function(done) {
+        if (process.env.NOCK_OFF) {
+          this.skip();
+        }
+
+        var mocks = nock(SERVER)
+            .get(DBNAME)
+            .replyWithError({code: 'ECONNRESET', message: 'socket hang up'})
+            .get('/bar')
+            .reply(200, {ok: true});
+
+        var cloudantClient = new Client({
+          maxAttempt: 10,
+          plugins: ['promises', testPlugin.ComplexPlugin2]
+        });
+        assert.equal(cloudantClient._plugins.length, 1);
+        assert.ok(cloudantClient._usePromises);
+
+        var options = {
+          url: SERVER + DBNAME,
+          auth: { username: ME, password: PASSWORD },
+          method: 'DELETE' // ComplexPlugin2 will set method to 'GET'
+        };
+        var p = cloudantClient.request(options).then(function(data) {
+          assert.ok(data.ok);
+
+          assert.equal(cloudantClient._plugins[0].onRequestCallCount, 1);
+          assert.equal(cloudantClient._plugins[0].onErrorCallCount, 1);
+          assert.equal(cloudantClient._plugins[0].onResponseCallCount, 0);
+
+          mocks.done();
+          done();
+        }).catch(function(err) {
+          assert.fail(`Unexpected reject: ${err}`);
+        });
+        assert.ok(p instanceof Promise);
+      });
+    });
+
+    describe('with ComplexPlugin3', function() {
+      it('performs request and calls request and response hooks only', function(done) {
+        if (process.env.NOCK_OFF) {
+          this.skip();
+        }
+
+        var mocks = nock(SERVER)
+          .get(DBNAME)
+          .times(2)
+          .reply(500, {
+            error: 'internal_server_error',
+            reason: 'Internal Server Error'
+          })
+          .delete('/bar')
+          .reply(200, {ok: true});
+
+        var cloudantClient = new Client({
+          maxAttempt: 10,
+          plugins: ['promises', testPlugin.ComplexPlugin3]
+        });
+        assert.equal(cloudantClient._plugins.length, 1);
+        assert.ok(cloudantClient._usePromises);
+
+        var options = {
+          url: SERVER + DBNAME,
+          auth: { username: ME, password: PASSWORD },
+          method: 'GET'
+        };
+        var p = cloudantClient.request(options).then(function(data) {
+          assert.ok(data.ok);
+
+          assert.equal(cloudantClient._plugins[0].onResponseCallCount, 2);
+
+          mocks.done();
+          done();
+        }).catch(function(err) {
+          assert.fail(`Unexpected reject: ${err}`);
+        });
+        assert.ok(p instanceof Promise);
+      });
+
+      it('performs request and calls request and error hooks only', function(done) {
+        if (process.env.NOCK_OFF) {
+          this.skip();
+        }
+
+        var mocks = nock(SERVER)
+            .get(DBNAME)
+            .replyWithError({code: 'ECONNRESET', message: 'socket hang up'});
+
+        var cloudantClient = new Client({
+          maxAttempt: 10,
+          plugins: ['promises', testPlugin.ComplexPlugin3]
+        });
+        assert.equal(cloudantClient._plugins.length, 1);
+        assert.ok(cloudantClient._usePromises);
+
+        var options = {
+          url: SERVER + DBNAME,
+          auth: { username: ME, password: PASSWORD },
+          method: 'GET'
+        };
+        var p = cloudantClient.request(options).then(function(data) {
+          assert.fail(`Unexpected resolve: ${data}`);
+        }).catch(function(err) {
+          assert.equal(err.code, 'ECONNRESET');
+          assert.equal(err.message, 'socket hang up');
+
+          assert.equal(cloudantClient._plugins[0].onResponseCallCount, 0);
+
+          mocks.done();
+          done();
+        });
+        assert.ok(p instanceof Promise);
+      });
+    });
+
+    describe('with multiple plugins', function() {
+      it('performs request and calls all response hooks', function(done) {
+        var mocks = nock(SERVER);
+        if (!process.env.NOCK_OFF) {
+          mocks
+            .get(DBNAME).times(3)
+            .reply(200, {doc_count: 0});
+        }
+
+        var cloudantClient = new Client({
+          maxAttempt: 3,
+          plugins: [
+            'promises',
+            testPlugin.PluginA,
+            testPlugin.PluginB,
+            testPlugin.PluginC,
+            testPlugin.PluginD
+          ]
+        });
+
+        var options = {
+          url: SERVER + DBNAME,
+          auth: { username: ME, password: PASSWORD },
+          method: 'GET'
+        };
+        var p = cloudantClient.request(options).then(function(data) {
+          assert.equal(data.doc_count, 0);
+          mocks.done();
+          done();
+        }).catch(function(err) {
+          assert.fail(`Unexpected reject: ${err}`);
+        });
+        assert.ok(p instanceof Promise);
+      });
+
+      it('performs request and calls all error hooks', function(done) {
+        if (process.env.NOCK_OFF) {
+          this.skip();
+        }
+
+        var mocks = nock(SERVER)
+          .get(DBNAME).times(3)
+          .replyWithError({code: 'ECONNRESET', message: 'socket hang up'});
+
+        var cloudantClient = new Client({ maxAttempt: 3,
+          plugins: [
+            'promises',
+            testPlugin.PluginA,
+            testPlugin.PluginB,
+            testPlugin.PluginC,
+            testPlugin.PluginD
+          ]
+        });
+
+        var options = {
+          url: SERVER + DBNAME,
+          auth: { username: ME, password: PASSWORD },
+          method: 'GET'
+        };
+        var p = cloudantClient.request(options).then(function(data) {
+          assert.fail(`Unexpected resolve: ${data}`);
+        }).catch(function(err) {
+          assert.equal(err.code, 'ECONNRESET');
+          assert.equal(err.message, 'socket hang up');
+
+          mocks.done();
+          done();
+        });
+        assert.ok(p instanceof Promise);
+      });
+    });
+  });
+});

--- a/test/clientutils.js
+++ b/test/clientutils.js
@@ -1,0 +1,268 @@
+// Copyright © 2017 IBM Corp. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/* global describe it afterEach */
+'use strict';
+
+const assert = require('assert');
+const nock = require('./nock.js');
+const request = require('request');
+const stream = require('stream');
+const testPlugin = require('./fixtures/testplugins.js');
+const utils = require('../lib/clientutils.js');
+
+const ME = process.env.cloudant_username || 'nodejs';
+const SERVER = `https://${ME}.cloudant.com`;
+
+describe('Client Utilities', function() {
+  afterEach(function() {
+    if (!process.env.NOCK_OFF) {
+      nock.cleanAll();
+    }
+  });
+
+  describe('processState', function() {
+    it('calls back without error if no response', function(done) {
+      var r = { response: undefined, state: { retry: false } };
+      utils.processState(r, function(stop) {
+        assert.equal(stop, undefined);
+        done();
+      });
+    });
+
+    it('calls back without error if retry', function(done) {
+      nock(SERVER)
+          .get('/')
+          .reply(200, {couchdb: 'Welcome'});
+
+      var r = { response: request.get(SERVER) };
+      r.state = {
+        attempt: 1,
+        abortWithResponse: undefined,
+        maxAttempt: 3,
+        retry: true,
+        retryDelay: 0
+      };
+      utils.processState(r, function(stop) {
+        assert.equal(stop, undefined);
+        done();
+      });
+    });
+
+    it('calls back with error if plugin issued abort', function(done) {
+      var r = {
+        clientCallback: function(e, r, d) {
+          assert.equal(e, 'error');
+          assert.equal(r, 'response');
+          assert.equal(d, 'data');
+        },
+        clientStream: new stream.PassThrough()
+      };
+
+      r.clientStream.on('error', function(e) {
+        assert.equal(e, 'error');
+      });
+      r.clientStream.on('response', function(r) {
+        assert.equal(r, 'response');
+      });
+      r.clientStream.on('data', function(d) {
+        assert.equal(d, 'data');
+      });
+
+      r.state = {
+        abortWithResponse: ['error', 'response', 'data'],
+        retry: false
+      };
+      utils.processState(r, function(stop) {
+        assert.equal(stop.message, 'Plugin issued abort');
+        done();
+      });
+    });
+
+    it('calls back with error if too many retries', function(done) {
+      nock(SERVER)
+          .get('/')
+          .reply(200, {couchdb: 'Welcome'});
+
+      var r = { response: request.get(SERVER) };
+      r.state = {
+        attempt: 3,
+        abortWithResponse: undefined,
+        maxAttempt: 3,
+        retry: true,
+        retryDelay: 0
+      };
+      utils.processState(r, function(stop) {
+        assert.equal(stop.message, 'No retry requested');
+        done();
+      });
+    });
+
+    it('calls back with error if no retry', function(done) {
+      nock(SERVER)
+          .get('/')
+          .reply(200, {couchdb: 'Welcome'});
+
+      var r = { response: request.get(SERVER) };
+      r.state = {
+        attempt: 1,
+        abortWithResponse: undefined,
+        maxAttempt: 3,
+        retry: false,
+        retryDelay: 0
+      };
+      utils.processState(r, function(stop) {
+        assert.equal(stop.message, 'No retry requested');
+        done();
+      });
+    });
+  });
+
+  describe('runHooks', function() {
+    it('exits early if no plugins', function(done) {
+      var r = { plugins: [] }; // no plugins
+      utils.runHooks('onRequest', r, 'data', function(err) {
+        done(err);
+      });
+    });
+
+    it('runs all plugin hooks', function(done) {
+      var plugin = new testPlugin.NoopPlugin(null, {});
+      var r = { plugins: [ plugin ] };
+      r.state = {
+        attempt: 1,
+        abortWithResponse: undefined,
+        maxAttempt: 3,
+        retry: false,
+        retryDelay: 0
+      };
+      utils.runHooks('onRequest', r, 'request', function(err) {
+        assert.equal(plugin.onRequestCallCount, 1);
+        assert.equal(plugin.onErrorCallCount, 0);
+        assert.equal(plugin.onResponseCallCount, 0);
+        done(err);
+      });
+    });
+
+    it('noop for missing plugin hook', function(done) {
+      var plugin = new testPlugin.NoopPlugin(null, {});
+      var r = { plugins: [ plugin ] };
+      utils.runHooks('someInvalidHookName', r, 'request', function(err) {
+        assert.equal(plugin.onRequestCallCount, 0);
+        assert.equal(plugin.onErrorCallCount, 0);
+        assert.equal(plugin.onResponseCallCount, 0);
+        done(err);
+      });
+    });
+  });
+
+  describe('wrapCallback', function() {
+    it('noop for undefined client callback', function() {
+      var r = { clientCallback: undefined }; // no client callback
+      assert.equal(utils.wrapCallback(r), undefined);
+    });
+
+    it('runs all plugin hooks and executes client callback', function(done) {
+      nock(SERVER)
+          .get('/')
+          .reply(200, {couchdb: 'Welcome'});
+
+      var plugin = new testPlugin.NoopPlugin(null, {});
+      var cb = function(e, r, d) {
+        assert.equal(e, undefined);
+        assert.equal(r.statusCode, 200);
+        assert.ok(d.toString('utf8').indexOf('"couchdb":"Welcome"') > -1);
+
+        assert.equal(plugin.onRequestCallCount, 0);
+        assert.equal(plugin.onErrorCallCount, 0);
+        assert.equal(plugin.onResponseCallCount, 1);
+      };
+      var r = { clientCallback: cb, plugins: [ plugin ] };
+      r.state = {
+        attempt: 1,
+        abortWithResponse: undefined,
+        maxAttempt: 3,
+        retry: false,
+        retryDelay: 0
+      };
+      r.response = request.get(SERVER, utils.wrapCallback(r, function(stop) {
+        assert.equal(stop.message, 'No retry requested');
+        done();
+      }));
+    });
+
+    it('runs all plugin hooks and skips client callback on retry', function(done) {
+      nock(SERVER)
+          .get('/')
+          .reply(200, {couchdb: 'Welcome'});
+
+      var plugin = new testPlugin.NoopPlugin(null, {});
+      var cb = function(e, r, d) {
+        assert.fail('Unexpected client callback execution');
+      };
+      var r = { clientCallback: cb, plugins: [ plugin ] };
+      r.state = {
+        attempt: 1,
+        abortWithResponse: undefined,
+        maxAttempt: 3,
+        retry: true,
+        retryDelay: 0
+      };
+      r.response = request.get(SERVER, utils.wrapCallback(r, function(stop) {
+        done(stop);
+      }));
+    });
+
+    it('runs all plugin hooks and executes client callback on abort', function(done) {
+      nock(SERVER)
+          .get('/')
+          .reply(200, {couchdb: 'Welcome'});
+
+      var plugin = new testPlugin.NoopPlugin(null, {});
+      var cb = function(e, r, d) {
+        assert.equal(e, 'error');
+        assert.equal(r, 'response');
+        assert.equal(d, 'data');
+
+        assert.equal(plugin.onRequestCallCount, 0);
+        assert.equal(plugin.onErrorCallCount, 0);
+        assert.equal(plugin.onResponseCallCount, 1);
+      };
+      var r = {
+        clientCallback: cb,
+        clientStream: new stream.PassThrough(),
+        plugins: [ plugin ]
+      };
+
+      r.clientStream.on('error', function(e) {
+        assert.equal(e, 'error');
+      });
+      r.clientStream.on('response', function(r) {
+        assert.equal(r, 'response');
+      });
+      r.clientStream.on('data', function(d) {
+        assert.equal(d, 'data');
+      });
+
+      r.state = {
+        abortWithResponse: ['error', 'response', 'data'],
+        retry: false
+      };
+      r.response = request.get(SERVER, utils.wrapCallback(r, function(stop) {
+        assert.equal(stop.message, 'Plugin issued abort');
+        done();
+      }));
+    });
+  });
+});

--- a/test/fixtures/testplugins.js
+++ b/test/fixtures/testplugins.js
@@ -1,0 +1,335 @@
+// Copyright © 2017 IBM Corp. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+'use strict';
+
+const assert = require('assert');
+const BasePlugin = require('../../plugins/base.js');
+
+const ME = process.env.cloudant_username || 'nodejs';
+const SERVER = `https://${ME}.cloudant.com`;
+
+// NoopPlugin for testing
+
+function NoopPlugin(client, opts) {
+  NoopPlugin.super_.apply(this, arguments);
+  this.onRequestCallCount = 0;
+  this.onErrorCallCount = 0;
+  this.onResponseCallCount = 0;
+}
+NoopPlugin.super_ = BasePlugin;
+NoopPlugin.prototype = Object.create(BasePlugin.prototype);
+
+NoopPlugin.prototype.onRequest = function(state, request, callback) {
+  this.onRequestCallCount++;
+  callback(state); // noop
+};
+NoopPlugin.prototype.onError = function(state, error, callback) {
+  this.onErrorCallCount++;
+  callback(state); // noop
+};
+NoopPlugin.prototype.onResponse = function(state, response, callback) {
+  this.onResponseCallCount++;
+  callback(state); // noop
+};
+
+// ComplexPlugin1 for testing
+//   - onRequest:  sets method to 'PUT'
+//                 adds 'ComplexPlugin1: foo' header
+//   - onError:    always retries
+//   - onResponse: always retries with retry delay
+
+function ComplexPlugin1(client, opts) {
+  ComplexPlugin1.super_.apply(this, arguments);
+  this.onRequestCallCount = 0;
+  this.onErrorCallCount = 0;
+  this.onResponseCallCount = 0;
+}
+ComplexPlugin1.super_ = BasePlugin;
+ComplexPlugin1.prototype = Object.create(BasePlugin.prototype);
+
+ComplexPlugin1.prototype.onRequest = function(state, request, callback) {
+  this.onRequestCallCount++;
+  request.method = 'PUT';
+  request.headers = { 'ComplexPlugin1': 'foo' };
+  callback(state);
+};
+ComplexPlugin1.prototype.onError = function(state, error, callback) {
+  this.onErrorCallCount++;
+  state.retry = true;
+  callback(state);
+};
+ComplexPlugin1.prototype.onResponse = function(state, response, callback) {
+  this.onResponseCallCount++;
+  state.retry = true;
+  if (state.attempt === 1) {
+    state.retryDelay = 10;
+  } else {
+    state.retryDelay *= 2;
+  }
+  callback(state);
+};
+
+// ComplexPlugin2 for testing
+//   - onRequest:  sets method to 'GET'
+//                 adds 'ComplexPlugin2: bar' header
+//   - onError:    submits GET /bar and returns response
+//   - onResponse: retries 401 responses once
+
+function ComplexPlugin2(client, opts) {
+  ComplexPlugin2.super_.apply(this, arguments);
+  this.onRequestCallCount = 0;
+  this.onErrorCallCount = 0;
+  this.onResponseCallCount = 0;
+}
+ComplexPlugin2.super_ = BasePlugin;
+ComplexPlugin2.prototype = Object.create(BasePlugin.prototype);
+
+ComplexPlugin2.prototype.onRequest = function(state, request, callback) {
+  this.onRequestCallCount++;
+  request.method = 'GET';
+  request.headers = { 'ComplexPlugin2': 'bar' };
+  callback(state);
+};
+ComplexPlugin2.prototype.onError = function(state, error, callback) {
+  this.onErrorCallCount++;
+  this._client(SERVER + '/bar', function(error, response, body) {
+    state.abortWithResponse = [error, response, body];
+    callback(state);
+  });
+};
+ComplexPlugin2.prototype.onResponse = function(state, response, callback) {
+  this.onResponseCallCount++;
+  if (state.attempt < state.maxAttempt) {
+    if (state.attempt === 1 && response.statusCode === 401) {
+      state.retry = true;
+    }
+  }
+  callback(state);
+};
+
+// ComplexPlugin3 for testing
+//   - onResponse: retries 5xx responses once, submitting a DELETE /bar on failure
+
+function ComplexPlugin3(client, opts) {
+  ComplexPlugin3.super_.apply(this, arguments);
+  this.onResponseCallCount = 0;
+}
+ComplexPlugin3.super_ = BasePlugin;
+ComplexPlugin3.prototype = Object.create(BasePlugin.prototype);
+
+ComplexPlugin3.prototype.onResponse = function(state, response, callback) {
+  this.onResponseCallCount++;
+  if (response.statusCode < 500) {
+    return callback(state);
+  }
+  if (state.attempt === 1) {
+    state.retry = true;
+    callback(state);
+  } else {
+    var options = { url: SERVER + '/bar', method: 'DELETE' };
+    this._client(options, function(error, response, body) {
+      state.abortWithResponse = [error, response, body];
+      callback(state);
+    });
+  }
+};
+
+// PluginA for testing
+//  - attempt 1
+//      * retryDelay set to 10
+//  - attempt 2
+//      * retryDelay set to 100
+//  - attempt 3
+//      * retryDelay set to 1000
+
+function PluginA(client, opts) {
+  PluginA.super_.apply(this, arguments);
+}
+PluginA.super_ = BasePlugin;
+PluginA.prototype = Object.create(BasePlugin.prototype);
+
+PluginA.prototype._hook = function(state, callback) {
+  switch (state.attempt) {
+    case 1:
+      assert.equal(state.retry, false);
+      assert.equal(state.retryDelay, 0);
+      state.retry = true;
+      state.retryDelay = 10;
+      break;
+    case 2:
+      assert.equal(state.retry, false);
+      assert.equal(state.retryDelay, 40);
+      state.retryDelay = 100;
+      break;
+    case 3:
+      assert.equal(state.retry, false);
+      assert.equal(state.retryDelay, 400);
+      state.retryDelay = 1000;
+      break;
+    default:
+      assert.fail('Too many attempts');
+  }
+  callback(state);
+};
+
+PluginA.prototype.onError = function(state, error, callback) {
+  this._hook(state, callback);
+};
+PluginA.prototype.onResponse = function(state, response, callback) {
+  this._hook(state, callback);
+};
+
+// PluginB for testing
+//  - attempt 1
+//      * retryDelay set to 20
+//  - attempt 2
+//      * retryDelay set to 200
+//  - attempt 3
+//      * retryDelay set to 2000
+
+function PluginB(client, opts) {
+  PluginB.super_.apply(this, arguments);
+}
+PluginB.super_ = BasePlugin;
+PluginB.prototype = Object.create(BasePlugin.prototype);
+
+PluginB.prototype._hook = function(state, callback) {
+  switch (state.attempt) {
+    case 1:
+      assert.equal(state.retry, true);
+      assert.equal(state.retryDelay, 10);
+      state.retryDelay = 20;
+      break;
+    case 2:
+      assert.equal(state.retry, false);
+      assert.equal(state.retryDelay, 100);
+      state.retry = true;
+      state.retryDelay = 200;
+      break;
+    case 3:
+      assert.equal(state.retry, false);
+      assert.equal(state.retryDelay, 1000);
+      state.retryDelay = 2000;
+      break;
+    default:
+      assert.fail('Too many attempts');
+  }
+  callback(state);
+};
+
+PluginB.prototype.onError = function(state, error, callback) {
+  this._hook(state, callback);
+};
+PluginB.prototype.onResponse = function(state, response, callback) {
+  this._hook(state, callback);
+};
+
+// PluginC for testing
+//  - attempt 1
+//      * retryDelay set to 30
+//  - attempt 2
+//      * retryDelay set to 300
+//  - attempt 3
+//      * retryDelay set to 3000
+
+function PluginC(client, opts) {
+  PluginC.super_.apply(this, arguments);
+}
+PluginC.super_ = BasePlugin;
+PluginC.prototype = Object.create(BasePlugin.prototype);
+
+PluginC.prototype._hook = function(state, callback) {
+  switch (state.attempt) {
+    case 1:
+      assert.equal(state.retry, true);
+      assert.equal(state.retryDelay, 20);
+      state.retryDelay = 30;
+      break;
+    case 2:
+      assert.equal(state.retry, true);
+      assert.equal(state.retryDelay, 200);
+      state.retryDelay = 300;
+      break;
+    case 3:
+      assert.equal(state.retry, false);
+      assert.equal(state.retryDelay, 2000);
+      state.retry = true;
+      state.retryDelay = 3000;
+      break;
+    default:
+      assert.fail('Too many attempts');
+  }
+  callback(state);
+};
+
+PluginC.prototype.onError = function(state, error, callback) {
+  this._hook(state, callback);
+};
+PluginC.prototype.onResponse = function(state, response, callback) {
+  this._hook(state, callback);
+};
+
+// PluginD for testing
+//  - attempt 1
+//      * retryDelay set to 40
+//  - attempt 2
+//      * retryDelay set to 400
+//  - attempt 3
+//      * <no action taken>
+
+function PluginD(client, opts) {
+  PluginD.super_.apply(this, arguments);
+}
+PluginD.super_ = BasePlugin;
+PluginD.prototype = Object.create(BasePlugin.prototype);
+
+PluginD.prototype._hook = function(state, callback) {
+  switch (state.attempt) {
+    case 1:
+      assert.equal(state.retry, true);
+      assert.equal(state.retryDelay, 30);
+      state.retryDelay = 40;
+      break;
+    case 2:
+      assert.equal(state.retry, true);
+      assert.equal(state.retryDelay, 300);
+      state.retryDelay = 400;
+      break;
+    case 3:
+      assert.equal(state.retry, true);
+      assert.equal(state.retryDelay, 3000);
+      break;
+    default:
+      assert.fail('Too many attempts');
+  }
+  callback(state);
+};
+
+PluginD.prototype.onError = function(state, error, callback) {
+  this._hook(state, callback);
+};
+PluginD.prototype.onResponse = function(state, response, callback) {
+  this._hook(state, callback);
+};
+
+module.exports = {
+  NoopPlugin: NoopPlugin,
+  ComplexPlugin1: ComplexPlugin1,
+  ComplexPlugin2: ComplexPlugin2,
+  ComplexPlugin3: ComplexPlugin3,
+  PluginA: PluginA,
+  PluginB: PluginB,
+  PluginC: PluginC,
+  PluginD: PluginD
+};


### PR DESCRIPTION
## What
Add new `CloudantClient` that supports multiple request interceptor plugins.

## How
Run intercepter hooks on `request`, `error` and `response` events.

## Examples
 - Creating a `CloudantClient`:
```js
var client = new CloudantClient({ maxAttempt: 10, plugins: [ 'cookieauth', 'retry5xx' ] });
client.request({ url: 'http://localhost:5984/mydb' })
  .on('response', function(resp) {
    console.log(resp.statusCode);
  });
```
- A `CloudantClient` plugin:
```js
function retry5xx(client, opts) {
  retry5xx.super_.apply(this, arguments);
}
retry5xx.super_ = BasePlugin;
retry5xx.prototype = Object.create(BasePlugin.prototype);

retry5xx.prototype.onResponse = function(state, response, callback) {
  if (response.statusCode >= 500) {
    state.retry = true; // retry request

    // set delay before next retry
    if (state.attempt === 1) {
      state.retryDelay = 10; // 10ms
    } else {
      state.retryDelay *= 2;
    }
  }
  callback(state);
};
```
_Note: Plugin implementations are not included in this PR._

## Testing
Includes additional unit tests.

## Issues
See #175.