### PR TITLE
Always run `processState` after plugin execution

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -146,47 +146,44 @@ CloudantClient.prototype._doRequest = function(options, callback) {
     request.state.attempt++;
     request.state.retry = false;
 
-    async.series([
-      function(callback) {
-        utils.runHooks('onRequest', request, request.options, callback);
-      },
-      function(callback) {
-        utils.processState(request, callback); // process request hook results
+    utils.runHooks('onRequest', request, request.options, function(err) {
+      if (err) {
+        debug(err);
       }
-    ], function(stop) {
-      if (stop) {
-        return done(stop); // request hooks failed
-      }
-      setTimeout(function() {
-        // do request
-        request.response = self._client(
-          request.options, utils.wrapCallback(request, done));
-
-        // pipe to client stream
-        request.eventPipe = new EventPipe(request.response, request.clientStream);
-
-        if (typeof request.clientCallback === 'undefined') {
-          // run hooks using response event listener
-          request.response
-            .on('error', function(error) {
-              utils.runHooks('onError', request, error, function() {
-                utils.processState(request, done); // process error hook results
-              });
-            })
-            .on('response', function(response) {
-              utils.runHooks('onResponse', request, response, function() {
-                utils.processState(request, done); // process response hook results
-              });
-            });
+      utils.processState(request, function(stop) {
+        if (stop) {
+          return done(stop); // request hooks failed
         }
-      }, request.state.retryDelay);
+        setTimeout(function() {
+          // do request
+          request.response = self._client(
+            request.options, utils.wrapCallback(request, done));
+
+          // pipe to client stream
+          request.eventPipe = new EventPipe(request.response, request.clientStream);
+
+          if (typeof request.clientCallback === 'undefined') {
+            // run hooks using response event listener
+            request.response
+              .on('error', function(error) {
+                utils.runHooks('onError', request, error, function() {
+                  utils.processState(request, done); // process error hook results
+                });
+              })
+              .on('response', function(response) {
+                utils.runHooks('onResponse', request, response, function() {
+                  utils.processState(request, done); // process response hook results
+                });
+              });
+          }
+        }, request.state.retryDelay);
+      });
     });
   }, function(stop) {
     return stop;
   });
 
-  // return stream to client
-  return request.clientStream;
+  return request.clientStream; // return stream to client
 };
 
 // public

--- a/lib/clientutils.js
+++ b/lib/clientutils.js
@@ -14,6 +14,7 @@
 'use strict';
 
 const async = require('async');
+const debug = require('debug')('clientutils');
 
 // send response to the client
 var sendResponseToClient = function(response, clientStream, clientCallback) {
@@ -86,6 +87,7 @@ var runHooks = function(hookName, r, data, end) {
       if (typeof plugin[hookName] !== 'function') {
         done(); // no hooks for plugin
       } else {
+        debug(`running hook ${hookName} for plugin '${plugin.name}'`);
         plugin[hookName](Object.assign({}, r.state), data, function(newState) {
           updateState(r.state, newState, done);
         });


### PR DESCRIPTION
Ensure `processState` is always executed even if plugin hooks fail.