### PR TITLE
Add request abort

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -120,6 +120,7 @@ CloudantClient.prototype._doRequest = function(options, callback) {
   }
 
   var request = {};
+  request.abort = false;
   request.clientCallback = callback;
   request.clientStream = new stream.PassThrough();
   request.clientStream.on('error', function(err) {
@@ -138,7 +139,14 @@ CloudantClient.prototype._doRequest = function(options, callback) {
     abortWithResponse: undefined
   };
 
-  async.doUntil(function(done) {
+  request.clientStream.abort = function() {
+    // aborts response during hook execution phase.
+    // note that once a "good" request is made, this abort function is
+    // monkey-patched with `request.abort()`.
+    request.abort = true;
+  };
+
+  async.forever(function(done) {
     request.options = Object.assign({}, options); // new copy
     request.response = undefined;
 
@@ -154,7 +162,15 @@ CloudantClient.prototype._doRequest = function(options, callback) {
         if (stop) {
           return done(stop); // request hooks failed
         }
+
+        debug(`delaying request for ${request.state.retryDelayMsecs} Msecs`);
+
         setTimeout(function() {
+          if (request.abort) {
+            debug('client issued abort during plugin execution');
+            return done(new Error('Client issued abort'));
+          }
+
           // do request
           request.response = self._client(
             request.options, utils.wrapCallback(request, done));
@@ -179,9 +195,7 @@ CloudantClient.prototype._doRequest = function(options, callback) {
         }, request.state.retryDelay);
       });
     });
-  }, function(stop) {
-    return stop;
-  });
+  }, function(err) { debug(err.message); });
 
   return request.clientStream; // return stream to client
 };

--- a/lib/clientutils.js
+++ b/lib/clientutils.js
@@ -56,7 +56,14 @@ var updateState = function(state, newState, callback) {
 
 // process state (following plugin execution)
 var processState = function(r, callback) {
-  if (r.state.abortWithResponse) {
+  if (r.abort) {
+    if (r.response) {
+      debug('client issued abort during plugin execution');
+      r.response.abort();
+    }
+    callback(new Error('Client issued abort'));
+  } else if (r.state.abortWithResponse) {
+    // => abort request and send `abortWithResponse` to client
     if (r.response) {
       r.response.abort();
     }
@@ -70,7 +77,15 @@ var processState = function(r, callback) {
     r.response.abort();
     callback(); // retry request
   } else {
-    r.state.retry = false; // => response ok || too many retries
+    // => processing error/response hooks
+    r.clientStream.abort = function() {
+      debug('client issued abort');
+      r.response.abort(); // monkey-patch real abort
+    };
+    if (r.state.retry) {
+      debug('too many retry attempts');
+      r.state.retry = false;
+    }
     if (r.eventPipe) {
       r.eventPipe.resume(); // replay captured events
     }

--- a/test/clientutils.js
+++ b/test/clientutils.js
@@ -95,7 +95,7 @@ describe('Client Utilities', function() {
           .get('/')
           .reply(200, {couchdb: 'Welcome'});
 
-      var r = { response: request.get(SERVER) };
+      var r = { abort: false, clientStream: {}, response: request.get(SERVER) };
       r.state = {
         attempt: 3,
         abortWithResponse: undefined,
@@ -114,7 +114,7 @@ describe('Client Utilities', function() {
           .get('/')
           .reply(200, {couchdb: 'Welcome'});
 
-      var r = { response: request.get(SERVER) };
+      var r = { abort: false, clientStream: {}, response: request.get(SERVER) };
       r.state = {
         attempt: 1,
         abortWithResponse: undefined,
@@ -188,7 +188,12 @@ describe('Client Utilities', function() {
         assert.equal(plugin.onErrorCallCount, 0);
         assert.equal(plugin.onResponseCallCount, 1);
       };
-      var r = { clientCallback: cb, plugins: [ plugin ] };
+      var r = {
+        abort: false,
+        clientCallback: cb,
+        clientStream: {},
+        plugins: [ plugin ]
+      };
       r.state = {
         attempt: 1,
         abortWithResponse: undefined,

--- a/test/fixtures/testplugins.js
+++ b/test/fixtures/testplugins.js
@@ -45,6 +45,42 @@ class NoopPlugin extends BasePlugin {
   }
 }
 
+// AlwaysRetry for testing
+//   - onRequest:  noop
+//   - onError:    always retries (with retry delay)
+//   - onResponse: always retries (with retry delay)
+
+class AlwaysRetry extends BasePlugin {
+  constructor(client, opts) {
+    super(client, opts);
+    this.onRequestCallCount = 0;
+    this.onErrorCallCount = 0;
+    this.onResponseCallCount = 0;
+  }
+
+  onError(state, error, callback) {
+    this.onErrorCallCount++;
+    state.retry = true;
+    if (state.attempt === 1) {
+      state.retryDelay = 500;
+    } else {
+      state.retryDelay *= 2;
+    }
+    callback(state);
+  }
+
+  onResponse(state, response, callback) {
+    this.onResponseCallCount++;
+    state.retry = true;
+    if (state.attempt === 1) {
+      state.retryDelay = 500;
+    } else {
+      state.retryDelay *= 2;
+    }
+    callback(state);
+  }
+}
+
 // ComplexPlugin1 for testing
 //   - onRequest:  sets method to 'PUT'
 //                 adds 'ComplexPlugin1: foo' header
@@ -319,6 +355,7 @@ class PluginD extends BasePlugin {
 
 module.exports = {
   NoopPlugin: NoopPlugin,
+  AlwaysRetry: AlwaysRetry,
   ComplexPlugin1: ComplexPlugin1,
   ComplexPlugin2: ComplexPlugin2,
   ComplexPlugin3: ComplexPlugin3,


### PR DESCRIPTION
## What
Implement `response.abort()`.

## How
Monkey-patch `request.clientStream.abort` with underlying `response.abort`.

## Testing
Includes additional unit test.