### PR TITLE
Override cfg on request

### DIFF
--- a/cloudant.js
+++ b/cloudant.js
@@ -16,7 +16,7 @@
 module.exports = Cloudant;
 
 var Nano = require('cloudant-nano');
-var debug = require('debug')('cloudant');
+var debug = require('debug')('cloudant:cloudant');
 var nanodebug = require('debug')('nano');
 var async = require('async');
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -20,20 +20,29 @@ const pkg = require('../package.json');
 const stream = require('stream');
 const utils = require('./clientutils.js');
 
+const DEFAULTS = {
+  maxAttempt: 3,
+  retryDelayMultiplier: 2,
+  retryInitialDelayMsecs: 500,
+  usePromises: false
+};
+
 /**
  * Create a Cloudant client for managing requests.
  *
- * @param {Object} opts - Request options.
+ * @param {Object} cfg - Request client configuration.
  */
-function CloudantClient(opts) {
-  this._opts = opts || {};
+function CloudantClient(cfg) {
+  cfg = cfg || {};
+  this._support_legacy_keys(cfg);
+  this._cfg = this._default_cfg = Object.assign({}, DEFAULTS, cfg);
 
   // support legacy options
-  if (typeof this._opts.maxAttempt === 'undefined') {
-    this._opts.maxAttempt = this._opts.retryAttempts;
+  if (typeof this._cfg.maxAttempt === 'undefined') {
+    this._cfg.maxAttempt = this._cfg.retryAttempts;
   }
-  if (typeof this._opts.retryInitialDelay === 'undefined') {
-    this._opts.retryInitialDelay = this._opts.retryTimeout;
+  if (typeof this._cfg.retryInitialDelayMsecs === 'undefined') {
+    this._cfg.retryInitialDelayMsecs = this._cfg.retryTimeout;
   }
 
   this._plugins = [];
@@ -43,18 +52,18 @@ function CloudantClient(opts) {
   this._initClient();
 
   // add plugins
-  if (this._opts.plugin) {
-    this.addPlugins(this._opts.plugin);
+  this._plugins = [];
+  if (this._cfg.plugin) {
+    this.addPlugins(this._cfg.plugin);
   }
-  // alias
-  if (this._opts.plugins) {
-    this.addPlugins(this._opts.plugins);
+  if (this._cfg.plugins) {
+    this.addPlugins(this._cfg.plugins);
   }
 }
 
 CloudantClient.prototype._initClient = function() {
   var protocol;
-  if (this._opts && this._opts.https === false) {
+  if (this._cfg && this._cfg.https === false) {
     protocol = require('http');
   } else {
     protocol = require('https'); // default to https
@@ -75,9 +84,9 @@ CloudantClient.prototype._initClient = function() {
     jar: false
   };
 
-  if (this._opts.requestDefaults) {
+  if (this._cfg.requestDefaults) {
     // allow user to override defaults
-    requestDefaults = Object.assign({}, requestDefaults, this._opts.requestDefaults);
+    requestDefaults = Object.assign({}, requestDefaults, this._cfg.requestDefaults);
   }
 
   this._client = require('request').defaults(requestDefaults);
@@ -132,10 +141,10 @@ CloudantClient.prototype._doRequest = function(options, callback) {
   // init state
   request.state = {
     attempt: 0,
-    maxAttempt: self._opts.maxAttempt || 3,
+    cfg: self._cfg,
     // following are editable by plugin hooks during execution
     retry: false,
-    retryDelay: 0,
+    retryDelayMsecs: 0,
     abortWithResponse: undefined
   };
 
@@ -153,14 +162,17 @@ CloudantClient.prototype._doRequest = function(options, callback) {
     // update state
     request.state.attempt++;
     request.state.retry = false;
+    request.state.sending = false;
 
     utils.runHooks('onRequest', request, request.options, function(err) {
-      if (err) {
-        debug(err);
-      }
       utils.processState(request, function(stop) {
+        if (request.state.retry) {
+          debug('onRequest hook issued retry');
+          return done();
+        }
         if (stop) {
-          return done(stop); // request hooks failed
+          debug(`onRequest hook issued abort: ${stop}`);
+          return done(stop);
         }
 
         debug(`delaying request for ${request.state.retryDelayMsecs} Msecs`);
@@ -172,6 +184,7 @@ CloudantClient.prototype._doRequest = function(options, callback) {
           }
 
           // do request
+          request.state.sending = true; // indicates onRequest hooks completed
           request.response = self._client(
             request.options, utils.wrapCallback(request, done));
 
@@ -192,12 +205,23 @@ CloudantClient.prototype._doRequest = function(options, callback) {
                 });
               });
           }
-        }, request.state.retryDelay);
+        }, request.state.retryDelayMsecs);
       });
     });
   }, function(err) { debug(err.message); });
 
   return request.clientStream; // return stream to client
+};
+
+CloudantClient.prototype._support_legacy_keys = function(cfg) {
+  // retryAttempts (old) -> maxAttempt (new)
+  if (typeof cfg.maxAttempt === 'undefined' && typeof cfg.retryAttempts !== 'undefined') {
+    cfg.maxAttempt = cfg.retryAttempts;
+  }
+  // retryTimeout (old) -> retryInitialDelayMsecs (new)
+  if (typeof cfg.retryInitialDelayMsecs === 'undefined' && typeof cfg.retryTimeout !== 'undefined') {
+    cfg.retryInitialDelayMsecs = cfg.retryTimeout;
+  }
 };
 
 // public
@@ -222,7 +246,7 @@ CloudantClient.prototype.addPlugins = function(plugins) {
     if (Plugin === 'promises') {
       // maps this.request -> this.doPromisesRequest
       debug('Adding plugin promises...');
-      self._usePromises = true;
+      self._cfg.usePromises = true;
       return;
     }
 
@@ -230,8 +254,8 @@ CloudantClient.prototype.addPlugins = function(plugins) {
       Plugin = require('../plugins/' + Plugin);
     }
 
-    debug(`Adding plugin '${Plugin.name}'...`);
-    self._plugins.push(new Plugin(self._client, self._opts));
+    debug(`Adding plugin '${Plugin.id}'...`);
+    self._plugins.push(new Plugin(self._client));
   });
 };
 
@@ -239,11 +263,23 @@ CloudantClient.prototype.addPlugins = function(plugins) {
  * Perform a request using this Cloudant client.
  *
  * @param {Object} options - HTTP options.
+ * @param {Object} cfg - Request client configuration (optional).
  * @param {requestCallback} callback - The callback that handles the response.
  */
-CloudantClient.prototype.request = function(options, callback) {
-  if (this._usePromises) {
-    // return a promise
+CloudantClient.prototype.request = function(options, cfg, callback) {
+  if (typeof cfg !== 'object') {
+    callback = cfg;
+    this._cfg = this._default_cfg; // use default
+  } else {
+    ['https', 'plugin', 'plugins', 'requestDefaults'].forEach(function(key) {
+      if (key in cfg) {
+        throw new Error(`Cannot specify '${key}' at request time`);
+      }
+    });
+    this._support_legacy_keys(cfg);
+    this._cfg = Object.assign({}, this._default_cfg, cfg);
+  }
+  if (this._cfg.usePromises) {
     return this._doPromisesRequest(options, callback);
   } else {
     return this._doRequest(options, callback);

--- a/lib/client.js
+++ b/lib/client.js
@@ -14,7 +14,7 @@
 'use strict';
 
 const async = require('async');
-const debug = require('debug')('client');
+const debug = require('debug')('cloudant:client');
 const EventPipe = require('./eventpipe.js');
 const pkg = require('../package.json');
 const stream = require('stream');

--- a/lib/clientutils.js
+++ b/lib/clientutils.js
@@ -46,8 +46,8 @@ var updateState = function(state, newState, callback) {
   if (newState.retry) {
     state.retry = true; // plugin requested a retry
   }
-  if (newState.retryDelay > state.retryDelay) {
-    state.retryDelay = newState.retryDelay; // set new retry delay
+  if (newState.retryDelayMsecs > state.retryDelayMsecs) {
+    state.retryDelayMsecs = newState.retryDelayMsecs; // set new retry delay
   }
   callback();
 };
@@ -71,20 +71,24 @@ var processState = function(r, callback) {
     var err = new Error('Plugin issued abort');
     err.skipClientCallback = true;
     callback(err); // no retry
-  } else if (!r.response) {
-    callback(); // running request hooks, continue
-  } else if (r.state.retry && r.state.attempt < r.state.maxAttempt) {
-    r.response.abort();
-    callback(); // retry request
-  } else {
-    // => processing error/response hooks
-    r.clientStream.abort = function() {
-      debug('client issued abort');
-      r.response.abort(); // monkey-patch real abort
-    };
+  } else if (r.state.retry && r.state.attempt < r.state.cfg.maxAttempt) {
+    // => retry request
+    if (r.response) {
+      r.response.abort(); // abort request
+    }
+    callback();
+  } else if (!r.state.sending) {
+    // => processing request hooks
     if (r.state.retry) {
       debug('too many retry attempts');
       r.state.retry = false;
+    }
+    callback();
+  } else {
+    // => processing error/response hooks
+    if (r.state.retry) {
+      debug('too many retry attempts');
+      r.state.retry = false; // => response ok || too many retries
     }
     if (r.eventPipe) {
       r.eventPipe.resume(); // replay captured events
@@ -102,7 +106,7 @@ var runHooks = function(hookName, r, data, end) {
       if (typeof plugin[hookName] !== 'function') {
         done(); // no hooks for plugin
       } else {
-        debug(`running hook ${hookName} for plugin '${plugin.name}'`);
+        debug(`running hook ${hookName} for plugin '${plugin.id}'`);
         plugin[hookName](Object.assign({}, r.state), data, function(newState) {
           updateState(r.state, newState, done);
         });

--- a/lib/clientutils.js
+++ b/lib/clientutils.js
@@ -14,7 +14,7 @@
 'use strict';
 
 const async = require('async');
-const debug = require('debug')('clientutils');
+const debug = require('debug')('cloudant:clientutils');
 
 // send response to the client
 var sendResponseToClient = function(response, clientStream, clientCallback) {

--- a/plugins/base.js
+++ b/plugins/base.js
@@ -17,13 +17,17 @@
  * Cloudant base plugin.
  *
  * @param {Object} client - HTTP client.
- * @param {Object} opts - Plugin options.
  */
 class BasePlugin {
-  constructor(client, opts) {
+  constructor(client) {
     this._client = client;
-    this._opts = opts;
+  }
+
+  get id() {
+    return this.constructor.id;
   }
 }
+
+BasePlugin.id = 'base';
 
 module.exports = BasePlugin;

--- a/plugins/cookieauth.js
+++ b/plugins/cookieauth.js
@@ -18,7 +18,7 @@
 // we exchange the credentials for a cookie which we remember and pass back with each
 // subsequent request.
 var async = require('async');
-var debug = require('debug')('cloudant');
+var debug = require('debug')('cloudant:cookieauth');
 var stream = require('stream');
 var u = require('url');
 var nullcallback = function() {};

--- a/plugins/retry429.js
+++ b/plugins/retry429.js
@@ -20,18 +20,18 @@ const BasePlugin = require('./base.js');
  */
 class Retry429Plugin extends BasePlugin {
   onResponse(state, response, callback) {
-    if (response.statusCode !== 429) {
-      state.retry = false; // success
-    } else {
+    if (response.statusCode === 429) {
       state.retry = true;
       if (state.attempt === 1) {
-        state.retryDelay = this._opts.retryInitialDelay || 500;
+        state.retryDelayMsecs = state.cfg.retryInitialDelayMsecs;
       } else {
-        state.retryDelay *= this._opts.retryDelayMultiplier || 2;
+        state.retryDelayMsecs *= state.cfg.retryDelayMultiplier;
       }
     }
     callback(state);
   }
 }
+
+Retry429Plugin.id = 'retry429';
 
 module.exports = Retry429Plugin;

--- a/plugins/retry5xx.js
+++ b/plugins/retry5xx.js
@@ -20,18 +20,18 @@ const BasePlugin = require('./base.js');
  */
 class Retry5xxPlugin extends BasePlugin {
   onResponse(state, response, callback) {
-    if (response.statusCode < 500) {
-      state.retry = false; // success
-    } else {
+    if (response.statusCode >= 500) {
       state.retry = true;
       if (state.attempt === 1) {
-        state.retryDelay = this._opts.retryInitialDelay || 500;
+        state.retryDelayMsecs = state.cfg.retryInitialDelayMsecs;
       } else {
-        state.retryDelay *= this._opts.retryDelayMultiplier || 2;
+        state.retryDelayMsecs *= state.cfg.retryDelayMultiplier;
       }
     }
     callback(state);
   }
 }
+
+Retry5xxPlugin.id = 'retry5xx';
 
 module.exports = Retry5xxPlugin;

--- a/plugins/retryerror.js
+++ b/plugins/retryerror.js
@@ -22,12 +22,14 @@ class RetryErrorPlugin extends BasePlugin {
   onError(state, error, callback) {
     state.retry = true;
     if (state.attempt === 1) {
-      state.retryDelay = this._opts.retryInitialDelay || 500;
+      state.retryDelayMsecs = state.cfg.retryInitialDelayMsecs;
     } else {
-      state.retryDelay *= this._opts.retryDelayMultiplier || 2;
+      state.retryDelayMsecs *= state.cfg.retryDelayMultiplier;
     }
     callback(state);
   }
 }
+
+RetryErrorPlugin.id = 'retryerror';
 
 module.exports = RetryErrorPlugin;

--- a/test/fixtures/testplugins.js
+++ b/test/fixtures/testplugins.js
@@ -81,6 +81,41 @@ class AlwaysRetry extends BasePlugin {
   }
 }
 
+// AlwaysRetry for testing
+//   - onRequest:  noop
+//   - onError:    always retries (with retry delay)
+//   - onResponse: always retries (with retry delay)
+
+function AlwaysRetry(client, opts) {
+  AlwaysRetry.super_.apply(this, arguments);
+  this.onRequestCallCount = 0;
+  this.onErrorCallCount = 0;
+  this.onResponseCallCount = 0;
+}
+AlwaysRetry.super_ = BasePlugin;
+AlwaysRetry.prototype = Object.create(BasePlugin.prototype);
+
+AlwaysRetry.prototype.onError = function(state, error, callback) {
+  this.onErrorCallCount++;
+  state.retry = true;
+  if (state.attempt === 1) {
+    state.retryDelay = 500;
+  } else {
+    state.retryDelay *= 2;
+  }
+  callback(state);
+};
+AlwaysRetry.prototype.onResponse = function(state, response, callback) {
+  this.onResponseCallCount++;
+  state.retry = true;
+  if (state.attempt === 1) {
+    state.retryDelay = 500;
+  } else {
+    state.retryDelay *= 2;
+  }
+  callback(state);
+};
+
 // ComplexPlugin1 for testing
 //   - onRequest:  sets method to 'PUT'
 //                 adds 'ComplexPlugin1: foo' header


### PR DESCRIPTION
## What
Allow client configuration to be changed at request time.

## Example
```js
var cfg = { usePromises: true };
cloudantClient.request('http://localhost:5984', cfg).then(function(data) {
  ...
```
_or_
```js
var cfg =  { retryInitialDelayMsecs: 750 };
cloudantClient.request('http://localhost:5984',cfg, function(err, resp, data) {
  ...
```
## Testing
Includes additional unit tests.