### PR TITLE
Implement state.stash

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -143,10 +143,17 @@ CloudantClient.prototype._doRequest = function(options, callback) {
     attempt: 0,
     cfg: self._cfg,
     // following are editable by plugin hooks during execution
+    abortWithResponse: undefined,
     retry: false,
-    retryDelayMsecs: 0,
-    abortWithResponse: undefined
+    retryDelayMsecs: 0
   };
+
+  // add plugin stash
+  request.plugin_stash = {};
+  request.plugins.forEach(function(plugin) {
+    // allow plugin hooks to share data via the request state
+    request.plugin_stash[plugin.id] = {};
+  });
 
   request.clientStream.abort = function() {
     // aborts response during hook execution phase.

--- a/lib/clientutils.js
+++ b/lib/clientutils.js
@@ -107,7 +107,9 @@ var runHooks = function(hookName, r, data, end) {
         done(); // no hooks for plugin
       } else {
         debug(`running hook ${hookName} for plugin '${plugin.id}'`);
-        plugin[hookName](Object.assign({}, r.state), data, function(newState) {
+        var oldState = Object.assign({}, r.state);
+        oldState.stash = r.plugin_stash[plugin.id]; // add stash
+        plugin[hookName](oldState, data, function(newState) {
           updateState(r.state, newState, done);
         });
       }

--- a/test/clientutils.js
+++ b/test/clientutils.js
@@ -197,7 +197,7 @@ describe('Client Utilities', function() {
 
     it('runs all plugin hooks', function(done) {
       var plugin = new testPlugin.NoopPlugin(null, {});
-      var r = { plugins: [ plugin ] };
+      var r = { plugins: [ plugin ], plugin_stash: { noop: {} } };
       r.state = {
         abortWithResponse: undefined,
         attempt: 1,
@@ -250,7 +250,8 @@ describe('Client Utilities', function() {
         abort: false,
         clientCallback: cb,
         clientStream: {},
-        plugins: [ plugin ]
+        plugins: [ plugin ],
+        plugin_stash: { noop: {} }
       };
       r.state = {
         abortWithResponse: undefined,
@@ -274,7 +275,11 @@ describe('Client Utilities', function() {
       var cb = function(e, r, d) {
         assert.fail('Unexpected client callback execution');
       };
-      var r = { clientCallback: cb, plugins: [ plugin ] };
+      var r = {
+        clientCallback: cb,
+        plugins: [ plugin ],
+        plugin_stash: { noop: {} }
+      };
       r.state = {
         abortWithResponse: undefined,
         attempt: 1,
@@ -305,7 +310,8 @@ describe('Client Utilities', function() {
       var r = {
         clientCallback: cb,
         clientStream: new stream.PassThrough(),
-        plugins: [ plugin ]
+        plugins: [ plugin ],
+        plugin_stash: { noop: {} }
       };
 
       r.clientStream.on('error', function(e) {

--- a/test/fixtures/testplugins.js
+++ b/test/fixtures/testplugins.js
@@ -211,17 +211,22 @@ class PluginA extends BasePlugin {
       case 1:
         assert.equal(state.retry, false);
         assert.equal(state.retryDelayMsecs, 0);
+        assert.equal(typeof state.stash.foo, 'undefined');
         state.retry = true;
         state.retryDelayMsecs = 10;
+        state.stash.foo = 'pluginA -- this hook has been called once';
         break;
       case 2:
         assert.equal(state.retry, false);
         assert.equal(state.retryDelayMsecs, 40);
+        assert.equal(state.stash.foo, 'pluginA -- this hook has been called once');
         state.retryDelayMsecs = 100;
+        state.stash.foo = 'pluginA -- this hook has been called twice';
         break;
       case 3:
         assert.equal(state.retry, false);
         assert.equal(state.retryDelayMsecs, 400);
+        assert.equal(state.stash.foo, 'pluginA -- this hook has been called twice');
         state.retryDelayMsecs = 1000;
         break;
       default:
@@ -255,17 +260,22 @@ class PluginB extends BasePlugin {
       case 1:
         assert.equal(state.retry, true);
         assert.equal(state.retryDelayMsecs, 10);
+        assert.equal(typeof state.stash.foo, 'undefined');
         state.retryDelayMsecs = 20;
+        state.stash.foo = 'pluginB -- this hook has been called once';
         break;
       case 2:
         assert.equal(state.retry, false);
         assert.equal(state.retryDelayMsecs, 100);
+        assert.equal(state.stash.foo, 'pluginB -- this hook has been called once');
         state.retry = true;
         state.retryDelayMsecs = 200;
+        state.stash.foo = 'pluginB -- this hook has been called twice';
         break;
       case 3:
         assert.equal(state.retry, false);
         assert.equal(state.retryDelayMsecs, 1000);
+        assert.equal(state.stash.foo, 'pluginB -- this hook has been called twice');
         state.retryDelayMsecs = 2000;
         break;
       default:
@@ -299,16 +309,21 @@ class PluginC extends BasePlugin {
       case 1:
         assert.equal(state.retry, true);
         assert.equal(state.retryDelayMsecs, 20);
+        assert.equal(typeof state.stash.foo, 'undefined');
         state.retryDelayMsecs = 30;
+        state.stash.foo = 'pluginC -- this hook has been called once';
         break;
       case 2:
         assert.equal(state.retry, true);
         assert.equal(state.retryDelayMsecs, 200);
+        assert.equal(state.stash.foo, 'pluginC -- this hook has been called once');
         state.retryDelayMsecs = 300;
+        state.stash.foo = 'pluginC -- this hook has been called twice';
         break;
       case 3:
         assert.equal(state.retry, false);
         assert.equal(state.retryDelayMsecs, 2000);
+        assert.equal(state.stash.foo, 'pluginC -- this hook has been called twice');
         state.retry = true;
         state.retryDelayMsecs = 3000;
         break;
@@ -343,16 +358,21 @@ class PluginD extends BasePlugin {
       case 1:
         assert.equal(state.retry, true);
         assert.equal(state.retryDelayMsecs, 30);
+        assert.equal(typeof state.stash.foo, 'undefined');
         state.retryDelayMsecs = 40;
+        state.stash.foo = 'pluginD -- this hook has been called once';
         break;
       case 2:
         assert.equal(state.retry, true);
         assert.equal(state.retryDelayMsecs, 300);
+        assert.equal(state.stash.foo, 'pluginD -- this hook has been called once');
         state.retryDelayMsecs = 400;
+        state.stash.foo = 'pluginD -- this hook has been called twice';
         break;
       case 3:
         assert.equal(state.retry, true);
         assert.equal(state.retryDelayMsecs, 3000);
+        assert.equal(state.stash.foo, 'pluginD -- this hook has been called twice');
         break;
       default:
         assert.fail('Too many attempts');


### PR DESCRIPTION
## What
Implement `state.stash`. Allows plugin hooks to share data via the request state.

## Testing
Adapted existing plugin tests.
