### PR TITLE
Updated docs.cloudant.com deprecated links

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,5 @@
 # UNRELEASED
+- [IMPROVED] Updated documentation by replacing deprecated Cloudant links with the latest bluemix.net links.
 
 # 1.10.0 (2017-11-01)
 - [UPGRADED] Upgrade package: cloudant-nano@6.7.0.

--- a/README.md
+++ b/README.md
@@ -402,7 +402,7 @@ Output:
         thandoodstrenterprourete: [ '_reader', '_writer' ],
         nodejs: [ '_reader', '_writer', '_admin', '_replicator' ] } }
 
-See the Cloudant API for full details](https://docs.cloudant.com/api.html#authorization)
+See the [Authorization] documentation for further details.
 
 ### Use an API Key
 
@@ -453,7 +453,7 @@ Output:
 
     { enable_cors: true, allow_credentials: true, origins: [ '*' ] }
 
-See <https://docs.cloudant.com/api.html#cors> for further details.
+See [CORS] for further details.
 
 
 ## Virtual Hosts
@@ -718,7 +718,7 @@ db.geo('city', 'city_points', query, function(er, result) {
 
 ## Cookie Authentication
 
-Cloudant supports making requests using Cloudant's [cookie authentication](https://docs.cloudant.com/authentication.html#cookie-authentication).
+Cloudant supports making requests using Cloudant's [cookie authentication](https://console.bluemix.net/docs/services/Cloudant/api/authentication.html#cookie-authentication).
 
 ~~~ js
 var Cloudant = require('cloudant');
@@ -1012,23 +1012,23 @@ and limitations under the License.
 
 * [Nano Library]
 * [Cloudant Documentation]
-* [Cloudant Query](https://docs.cloudant.com/cloudant_query.html)
-* [Cloudant Search](https://docs.cloudant.com/search.html)
-* [Authentication](https://docs.cloudant.com/authentication.html)
-* [Authorization](https://docs.cloudant.com/authorization.html)
-* [CORS](https://docs.cloudant.com/cors.html)
-* [Issues](https://github.com/cloudant/nodejs-cloudant/issues)
-* [Follow library](https://github.com/iriscouch/follow)
+* [Cloudant Query]
+* [Cloudant Search]
+* [Authentication]
+* [Authorization]
+* [CORS]
+* [Issues]
+* [Follow library]
 
 [Nano Library]: https://github.com/cloudant-labs/cloudant-nano
-[Cloudant Documentation]: https://docs.cloudant.com/
-[Cloudant Query]: https://docs.cloudant.com/cloudant_query.html
-[Cloudant Search]: https://docs.cloudant.com/search.html
-[Cloudant Geospatial]: https://docs.cloudant.com/geo.html
-[Authentication]: https://docs.cloudant.com/authentication.html
-[Authorization]: https://docs.cloudant.com/authorization.html
+[Cloudant Documentation]: https://console.bluemix.net/docs/services/Cloudant/cloudant.html#overview
+[Cloudant Query]: https://console.bluemix.net/docs/services/Cloudant/api/cloudant_query.html#query
+[Cloudant Search]: https://console.bluemix.net/docs/services/Cloudant/api/search.html
+[Cloudant Geospatial]: https://console.bluemix.net/docs/services/Cloudant/api/cloudant-geo.html#cloudant-geospatial
+[Authentication]: https://console.bluemix.net/docs/services/Cloudant/api/authentication.html
+[Authorization]: https://console.bluemix.net/docs/services/Cloudant/api/authorization.html#authorization
 [geojson]: http://geojson.org/
-[CORS]: https://docs.cloudant.com/cors.html
+[CORS]: https://console.bluemix.net/docs/services/Cloudant/api/cors.html#cors
 [Issues]: https://github.com/cloudant/nodejs-cloudant/issues
-[Follow library]: https://github.com/iriscouch/follow
+[Follow library]: https://github.com/cloudant-labs/cloudant-follow
 [request]: https://github.com/request/request

--- a/cloudant.js
+++ b/cloudant.js
@@ -104,7 +104,7 @@ function Cloudant(options, callback) {
         body: options }, callback);
     };
 
-    // https://docs.cloudant.com/geo.html
+    // https://console.bluemix.net/docs/services/Cloudant/api/cloudant-geo.html#cloudant-geospatial
     var geo = function(docName, indexName, query, callback) {
       var path = encodeURIComponent(db) + '/_design/' +
                  encodeURIComponent(docName) + '/_geo/' +
@@ -112,13 +112,13 @@ function Cloudant(options, callback) {
       return nano.request({path: path, qs: query}, callback);
     };
 
-    // https://docs.cloudant.com/api.html#viewing-permissions
+    // https://console.bluemix.net/docs/services/Cloudant/api/authorization.html#viewing-permissions
     var get_security = function(callback) { // eslint-disable-line camelcase
       var path = '_api/v2/db/' + encodeURIComponent(db) + '/_security'; // eslint-disable-line camelcase
       return nano.request({ path: path }, callback);
     };
 
-    // https://docs.cloudant.com/api.html#modifying-permissions
+    // https://console.bluemix.net/docs/services/Cloudant/api/authorization.html#modifying-permissions
     var set_security = function(permissions, callback) { // eslint-disable-line camelcase
       var path = '_api/v2/db/' + encodeURIComponent(db) + '/_security';
       return nano.request({ path: path,
@@ -126,8 +126,8 @@ function Cloudant(options, callback) {
         body: {cloudant: permissions} }, callback);
     };
 
-    // https://docs.cloudant.com/api.html#list-all-indexes &
-    // https://docs.cloudant.com/api.html#creating-a-new-index
+    // https://console.bluemix.net/docs/services/Cloudant/api/cloudant_query.html#list-all-cloudant-query-indexes &
+    // https://console.bluemix.net/docs/services/Cloudant/api/cloudant_query.html#creating-an-index
     var index = function(definition, callback) {
       // if no definition is provided, then the user wants see all the indexes
       if (typeof definition === 'function') {
@@ -141,7 +141,7 @@ function Cloudant(options, callback) {
       }
     };
 
-    // https://docs.cloudant.com/api.html#deleting-an-index
+    // https://console.bluemix.net/docs/services/Cloudant/api/cloudant_query.html#deleting-an-index
     var index_del = function(spec, callback) { // eslint-disable-line camelcase
       spec = spec || {};
       if (!spec.ddoc) { throw new Error('index.del() must specify a "ddoc" value'); }
@@ -154,7 +154,7 @@ function Cloudant(options, callback) {
       return nano.request({ path: path, method: 'delete' }, callback);
     };
 
-    // https://docs.cloudant.com/api.html#finding-documents-using-an-index
+    // https://console.bluemix.net/docs/services/Cloudant/api/cloudant_query.html#finding-documents-by-using-an-index
     var find = function(query, callback) {
       return nano.request({ path: encodeURIComponent(db) + '/_find',
         method: 'post',
@@ -178,17 +178,17 @@ function Cloudant(options, callback) {
   nano._use = nano.use;
   nano.use = nano.db.use = use;
 
-  // https://docs.cloudant.com/api.html#creating-api-keys
+  // https://console.bluemix.net/docs/services/Cloudant/api/authorization.html#creating-api-keys
   var generate_api_key = function(callback) { // eslint-disable-line camelcase
     return nano.request({ path: '_api/v2/api_keys', method: 'post' }, callback);
   };
 
-  // https://docs.cloudant.com/api.html#reading-the-cors-configuration
+  // https://console.bluemix.net/docs/services/Cloudant/api/cors.html#reading-the-cors-configuration
   var get_cors = function(callback) { // eslint-disable-line camelcase
     return nano.request({ path: '_api/v2/user/config/cors' }, callback);
   };
 
-  // https://docs.cloudant.com/api.html#setting-the-cors-configuration
+  // https://console.bluemix.net/docs/services/Cloudant/api/cors.html#setting-the-cors-configuration
   var set_cors = function(configuration, callback) { // eslint-disable-line camelcase
     return nano.request({path: '_api/v2/user/config/cors',
       method: 'put',
@@ -201,7 +201,7 @@ function Cloudant(options, callback) {
     callback(null, null);
   };
 
-  // https://docs.cloudant.com/api.html#setting-the-cors-configuration
+  // https://console.bluemix.net/docs/services/Cloudant/api/cors.html#setting-the-cors-configuration
   set_cors = function(configuration, callback) { // eslint-disable-line camelcase
     return nano.request({path: '_api/v2/user/config/cors',
       method: 'put',


### PR DESCRIPTION
## What

Updated `docs.cloudant.com` links to the latest Bluemix `console.bluemix.net/docs/` documentation.

## How

- Replaced all deprecated links in library with the appropriate Bluemix doc links

## Testing

No new tests.

fixes #237 