### PR TITLE
Support legacy custom plugins

### DIFF
--- a/cloudant.js
+++ b/cloudant.js
@@ -211,7 +211,11 @@ function Cloudant(options, callback) {
   if (callback) {
     nano.cc.addPlugins('cookieauth');
     nano.ping(function(error, pong) {
-      callback(error, nano, pong);
+      if (error) {
+        callback(error);
+      } else {
+        callback(error, nano, pong);
+      }
     });
   }
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -34,35 +34,54 @@ const DEFAULTS = {
  */
 class CloudantClient {
   constructor(cfg) {
+    var self = this;
+
     cfg = cfg || {};
-    this._supportLegacyKeys(cfg);
-    this._cfg = this._default_cfg = Object.assign({}, DEFAULTS, cfg);
+    self._supportLegacyKeys(cfg);
+    self._cfg = self._default_cfg = Object.assign({}, DEFAULTS, cfg);
 
     // support legacy options
-    if (typeof this._cfg.maxAttempt === 'undefined') {
-      this._cfg.maxAttempt = this._cfg.retryAttempts;
+    if (typeof self._cfg.maxAttempt === 'undefined') {
+      self._cfg.maxAttempt = self._cfg.retryAttempts;
     }
-    if (typeof this._cfg.retryInitialDelayMsecs === 'undefined') {
-      this._cfg.retryInitialDelayMsecs = this._cfg.retryTimeout;
+    if (typeof self._cfg.retryInitialDelayMsecs === 'undefined') {
+      self._cfg.retryInitialDelayMsecs = self._cfg.retryTimeout;
     }
 
-    this._plugins = this._pluginIds = [];
-    this._usePromises = false;
+    var client;
+    self._plugins = [];
+    self._pluginIds = [];
+    self._usePromises = false;
+    self.useLegacyPlugin = false;
+
+    // build plugin array
+    var plugins = [];
+    if (typeof this._cfg.plugin === 'undefined' && typeof this._cfg.plugins === 'undefined') {
+      plugins = ['cookieauth']; // default
+    } else {
+      [].concat(self._cfg.plugin).concat(self._cfg.plugins).forEach(function(plugin) {
+        if (typeof plugin === 'function' && !(plugin._pluginVersion >= 2)) {
+          if (self.useLegacyPlugin) {
+            throw new Error('Using multiple legacy plugins in not supported');
+          } else {
+            debug('Using legacy plugin');
+            self.useLegacyPlugin = true;
+            client = plugin; // use legacy plugin as client
+            return;
+          }
+        }
+        plugins.push(plugin);
+      });
+    }
 
     // initialize the internal client
-    this._initClient();
-
-    this._plugins = [];
+    self._initClient(client);
 
     // add plugins
-    var plugins = ['cookieauth']; // default
-    if (typeof this._cfg.plugin !== 'undefined' || typeof this._cfg.plugins !== 'undefined') {
-      plugins = [].concat(this._cfg.plugin).concat(this._cfg.plugins);
-    }
-    this.addPlugins(plugins);
+    self.addPlugins(plugins);
   }
 
-  _initClient() {
+  _initClient(client) {
     var protocol;
     if (this._cfg && this._cfg.https === false) {
       protocol = require('http');
@@ -90,7 +109,13 @@ class CloudantClient {
       requestDefaults = Object.assign({}, requestDefaults, this._cfg.requestDefaults);
     }
 
-    this._client = require('request').defaults(requestDefaults);
+    this.requestDefaults = requestDefaults; // expose request defaults
+
+    if (typeof client === 'undefined') {
+      this._client = require('request').defaults(requestDefaults);
+    } else {
+      this._client = client;
+    }
   }
 
   _doPromisesRequest(options, callback) {

--- a/lib/client.js
+++ b/lib/client.js
@@ -15,7 +15,7 @@
 
 const async = require('async');
 const debug = require('debug')('cloudant:client');
-const EventPipe = require('./eventpipe.js');
+const EventRelay = require('./eventrelay.js');
 const pkg = require('../package.json');
 const stream = require('stream');
 const utils = require('./clientutils.js');
@@ -64,7 +64,7 @@ class CloudantClient {
           if (self.useLegacyPlugin) {
             throw new Error('Using multiple legacy plugins in not supported');
           } else {
-            debug('Using legacy plugin');
+            debug('Using legacy plugin.');
             self.useLegacyPlugin = true;
             client = plugin; // use legacy plugin as client
             return;
@@ -82,6 +82,12 @@ class CloudantClient {
   }
 
   _initClient(client) {
+    if (typeof client !== 'undefined') {
+      debug('Using custom client.');
+      this._client = client;
+      return;
+    }
+
     var protocol;
     if (this._cfg && this._cfg.https === false) {
       protocol = require('http');
@@ -109,13 +115,10 @@ class CloudantClient {
       requestDefaults = Object.assign({}, requestDefaults, this._cfg.requestDefaults);
     }
 
-    this.requestDefaults = requestDefaults; // expose request defaults
+    debug('Using request options: %j', requestDefaults);
 
-    if (typeof client === 'undefined') {
-      this._client = require('request').defaults(requestDefaults);
-    } else {
-      this._client = client;
-    }
+    this.requestDefaults = requestDefaults; // expose request defaults
+    this._client = require('request').defaults(requestDefaults);
   }
 
   _doPromisesRequest(options, callback) {
@@ -162,6 +165,8 @@ class CloudantClient {
       debug(err);
     });
 
+    request.eventRelay = new EventRelay(request.clientStream);
+
     request.plugins = self._plugins;
 
     // init state
@@ -190,6 +195,11 @@ class CloudantClient {
 
     var noClientCallback = typeof request.clientCallback === 'undefined';
 
+    if (!noClientCallback) {
+      // disable event piping if the client has specified a callback
+      request.eventRelay.disablePiping();
+    }
+
     async.forever(function(done) {
       request.options = Object.assign({}, options); // new copy
       request.response = undefined;
@@ -199,32 +209,37 @@ class CloudantClient {
       request.state.retry = false;
       request.state.sending = false;
 
+      debug(`Request attempt: ${request.state.attempt}`);
+
       utils.runHooks('onRequest', request, request.options, function(err) {
         utils.processState(request, function(stop) {
           if (request.state.retry) {
-            debug('onRequest hook issued retry');
+            debug('The onRequest hook issued retry.');
             return done();
           }
           if (stop) {
-            debug(`onRequest hook issued abort: ${stop}`);
+            debug(`The onRequest hook issued abort: ${stop}`);
             return done(stop);
           }
 
-          debug(`delaying request for ${request.state.retryDelayMsecs} Msecs`);
+          debug(`Delaying request for ${request.state.retryDelayMsecs} Msecs.`);
 
           setTimeout(function() {
             if (request.abort) {
-              debug('client issued abort during plugin execution');
+              debug('Client issued abort during plugin execution.');
               return done(new Error('Client issued abort'));
             }
 
             // do request
             request.state.sending = true; // indicates onRequest hooks completed
+
+            debug('Submitting request: %j', request.options);
+
             request.response = self._client(
               request.options, utils.wrapCallback(request, done));
 
-            // pipe to client stream
-            request.eventPipe = new EventPipe(request.response, request.clientStream, noClientCallback);
+            request.eventRelay.clear();
+            request.eventRelay.setSource(request.response);
 
             if (noClientCallback) {
               // run hooks using response event listener
@@ -284,7 +299,7 @@ class CloudantClient {
       }
       if (Plugin === 'promises') {
         // maps this.request -> this.doPromisesRequest
-        debug('Adding plugin promises...');
+        debug('Adding plugin promises.');
         self._cfg.usePromises = true;
         return;
       }
@@ -294,9 +309,9 @@ class CloudantClient {
       }
 
       if (self._pluginIds.indexOf(Plugin.id) !== -1) {
-        debug(`Not adding duplicate plugin '${Plugin.id}'.`);
+        debug(`Not adding duplicate plugin: '${Plugin.id}'`);
       } else {
-        debug(`Adding plugin '${Plugin.id}'...`);
+        debug(`Adding plugin: '${Plugin.id}'`);
         self._plugins.push(new Plugin(self._client, Object.assign({}, self._cfg)));
         self._pluginIds.push(Plugin.id);
       }

--- a/lib/clientutils.js
+++ b/lib/clientutils.js
@@ -82,6 +82,12 @@ var processState = function(r, callback) {
     // => the response is "good" and can be returned to the awaiting client
     //    OR
     //    too many retry attempts; the "bad" response must be returned to the client
+    if (r.response) {
+      r.clientStream.abort = function() {
+        debug('client issued abort');
+        r.response.abort(); // monkey-patch real abort
+      };
+    }
     if (r.state.retry) {
       debug('too many retry attempts');
       r.state.retry = false;

--- a/lib/clientutils.js
+++ b/lib/clientutils.js
@@ -18,6 +18,7 @@ const debug = require('debug')('cloudant:clientutils');
 
 // send response to the client
 var sendResponseToClient = function(response, clientStream, clientCallback) {
+  debug('An alternative response will be returned to the client');
   // response = [<error>, <response>, <data>]
   if (response[0]) {
     clientStream.emit('error', response[0]);
@@ -59,7 +60,7 @@ var processState = function(r, callback) {
   if (r.abort) {
     // => client has called for the request to be aborted
     if (r.response) {
-      debug('client issued abort during plugin execution');
+      debug('Client issued abort during plugin execution.');
       r.response.abort();
     }
     callback(new Error('Client issued abort')); // callback with error to prevent request retry
@@ -77,6 +78,7 @@ var processState = function(r, callback) {
     if (r.response) {
       r.response.abort();
     }
+    debug('Plugin issued a retry.');
     callback(); // callback without error in order to retry the request
   } else {
     // => the response is "good" and can be returned to the awaiting client
@@ -84,12 +86,12 @@ var processState = function(r, callback) {
     //    too many retry attempts; the "bad" response must be returned to the client
     if (r.response) {
       r.clientStream.abort = function() {
-        debug('client issued abort');
+        debug('Client issued abort.');
         r.response.abort(); // monkey-patch real abort
       };
     }
     if (r.state.retry) {
-      debug('too many retry attempts');
+      debug('Too many retry attempts.');
       r.state.retry = false;
     }
     if (!r.state.sending) {
@@ -97,9 +99,9 @@ var processState = function(r, callback) {
       callback(); // callback without error to proceed with executing the client's request
     } else {
       // processing 'onError' or 'onResponse' hooks
-      if (r.eventPipe) {
+      if (r.eventRelay) {
         // pass response through to awaiting client
-        r.eventPipe.resume();
+        r.eventRelay.resume();
       }
       callback(new Error('No retry requested')); // no retry
     }
@@ -115,7 +117,7 @@ var runHooks = function(hookName, r, data, end) {
       if (typeof plugin[hookName] !== 'function') {
         done(); // no hooks for plugin
       } else {
-        debug(`running hook ${hookName} for plugin '${plugin.id}'`);
+        debug(`Running hook ${hookName} for plugin '${plugin.id}'.`);
         var oldState = Object.assign({}, r.state);
         oldState.stash = r.plugin_stash[plugin.id]; // add stash
         plugin[hookName](oldState, data, function(newState) {
@@ -129,14 +131,17 @@ var runHooks = function(hookName, r, data, end) {
 // wrap client callback to allow for plugin hook execution
 var wrapCallback = function(r, done) {
   if (typeof r.clientCallback === 'undefined') {
-    return undefined; // noop - run hooks using response event listener
+    debug('Running hooks using response event listener');
+    return undefined; // noop
   } else {
+    debug('Running hooks using wrapped client callback.');
     // return wrapped callback
     return function(error, response, body) {
       var cb = function() {
         processState(r, function(stop) {
           if (stop) {
             if (!stop.skipClientCallback) {
+              debug('Running client callback...');
               r.clientCallback(error, response, body);
             }
             done(stop);

--- a/lib/eventrelay.js
+++ b/lib/eventrelay.js
@@ -13,35 +13,61 @@
 // limitations under the License.
 'use strict';
 
+const debug = require('debug')('cloudant:eventrelay');
+
 /**
- * Pipe all events from a source emitter to a target emitter.
+ * Relay all events from a source emitter to a target emitter.
  *
  * @param {Object} source - Source event emitter.
  * @param {Object} target - Target event emitter.
- * @param {boolean} pipeData - Attach source stream to target stream on resume.
  */
-class EventPipe {
-  constructor(source, target, pipeData) {
+class EventRelay {
+  constructor(source, target) {
     var self = this;
 
-    self._source = source;
+    if (typeof target === 'undefined') {
+      target = source;
+      source = {};
+    }
+
+    self.setSource(source || {});
     self._target = target;
 
+    self._disablePiping = false;
     self._eventsStash = [];
     self._paused = true;
-    self._pipeData = pipeData || false; // default: false
+    self._pipeData = false; // default
 
-    self.clear();
+    // monkey-patch the target pipe function
+    var oldPipe = self._target.pipe;
+    self._target.pipe = function() {
+      debug('Target stream is being piped.');
+      self._pipeData = true;
+      return oldPipe.apply(self._target, arguments);
+    };
+  }
+
+  // Set a new source event emitter.
+  setSource(source) {
+    var self = this;
+
+    debug('Setting new source stream.');
+    self._source = source;
+
+    if (typeof source === 'undefined') {
+      return;
+    }
 
     // monkey-patch the source emit function
     var oldEmit = self._source.emit;
     self._source.emit = function() {
       var args = arguments;
-      if (self._pipeData) {
+      if (!self._disablePiping && self._pipeData) {
         if (args[0] === 'response') {
-          // will resume flow when client calls `EventPipe.resume()`
+          // will resume flow when client calls `EventRelay.resume()`
+          debug('Received \'response\' event. Pausing source stream.');
           self._source.pause();
-        } else if (['data', 'end'].indexOf(args[0]) !== -1) {
+        } else if (args[0] === 'data' || args[0] === 'end') {
           // don't emit on target as data is pushed via pipe
           return oldEmit.apply(self._source, arguments);
         }
@@ -57,22 +83,35 @@ class EventPipe {
 
   // Clear all stashed events.
   clear() {
+    debug('Clearing all previously stashed events.');
     this._eventsStash = [];
   }
 
-  // Pause event pipe.
+  // Disable event piping.
+  disablePiping() {
+    debug('Disabling piping in event relay.');
+    this._disablePiping = true;
+  }
+
+  // Pause event relay.
   pause() {
+    debug('Pausing event relay.');
     this._paused = true;
   }
 
-  // Resume event pipe and fire all stashed events.
+  // Resume event relay and fire all stashed events.
   resume() {
     var self = this;
     self._paused = false;
 
-    if (self._pipeData) {
+    debug('Relaying captured events to target stream.');
+
+    if (!self._disablePiping && self._pipeData) {
+      debug('Piping data from source to target.');
       self._source.pipe(self._target);
       self._source.resume();
+    } else {
+      debug('Target stream is not being piped.');
     }
 
     var eventNames;
@@ -88,4 +127,4 @@ class EventPipe {
   }
 }
 
-module.exports = EventPipe;
+module.exports = EventRelay;

--- a/plugins/base.js
+++ b/plugins/base.js
@@ -62,5 +62,6 @@ class BasePlugin {
 }
 
 BasePlugin.id = 'base';
+BasePlugin._pluginVersion = 2;
 
 module.exports = BasePlugin;

--- a/plugins/cookieauth.js
+++ b/plugins/cookieauth.js
@@ -96,6 +96,9 @@ class CookiePlugin extends BasePlugin {
     var parsed = u.parse(req.url);
     var auth = parsed.auth;
 
+    delete parsed.auth;
+    delete parsed.href;
+
     if (!auth) {
       debug('Missing credentials - skipping cookie authentication.');
       state.stash.credentials = null;
@@ -116,6 +119,7 @@ class CookiePlugin extends BasePlugin {
         if (self.baseUrl && self.cookieJar.getCookies(self.baseUrl, {expire: true}).length > 0) {
           debug('There is already a valid session cookie in the jar.');
           req.jar = self.cookieJar;
+          req.url = u.format(parsed); // remove credentials from request
           return callback(state);
         }
       }
@@ -131,6 +135,7 @@ class CookiePlugin extends BasePlugin {
       if (error) {
         debug(error.message);
       } else {
+        req.url = u.format(parsed); // remove credentials from request
         req.jar = self.cookieJar; // add jar
       }
       callback(state);

--- a/test/client.js
+++ b/test/client.js
@@ -364,6 +364,30 @@ describe('CloudantClient', function() {
         done();
       }, 8000);
     });
+
+    it('after plugin execution phase', function(done) {
+      var mocks = nock(SERVER)
+          .get(DBNAME)
+          .reply(200, {doc_count: 0});
+
+      var cloudantClient = new Client();
+      assert.equal(cloudantClient._plugins.length, 1);
+
+      var options = {
+        url: SERVER + DBNAME,
+        auth: { username: ME, password: PASSWORD },
+        method: 'GET'
+      };
+      var r = cloudantClient.request(options)
+        .on('response', function(resp) {
+          assert.equal(resp.statusCode, 200);
+          r.abort(); // abort request
+        })
+        .on('abort', function() {
+          mocks.done();
+          done();
+        });
+    });
   });
 
   describe('using callbacks', function() {

--- a/test/clientutils.js
+++ b/test/clientutils.js
@@ -34,7 +34,7 @@ describe('Client Utilities', function() {
 
   describe('processState', function() {
     it('calls back without error if no response', function(done) {
-      var r = { response: undefined, state: { retry: false } };
+      var r = { clientStream: {}, response: undefined, state: { retry: false } };
       utils.processState(r, function(stop) {
         assert.equal(stop, undefined);
         done();
@@ -152,7 +152,7 @@ describe('Client Utilities', function() {
           .get('/')
           .reply(200, {couchdb: 'Welcome'});
 
-      var r = { response: request.get(SERVER) };
+      var r = { clientStream: {}, response: request.get(SERVER) };
       r.state = {
         abortWithResponse: undefined,
         attempt: 1,
@@ -171,7 +171,7 @@ describe('Client Utilities', function() {
           .get('/')
           .reply(200, {couchdb: 'Welcome'});
 
-      var r = { response: request.get(SERVER) };
+      var r = { clientStream: {}, response: request.get(SERVER) };
       r.state = {
         abortWithResponse: undefined,
         attempt: 3,

--- a/test/eventrelay.js
+++ b/test/eventrelay.js
@@ -19,13 +19,20 @@ const assert = require('assert');
 const events = require('events');
 const stream = require('stream');
 
-const EventPipe = require('../lib/eventpipe.js');
+const EventRelay = require('../lib/eventrelay.js');
 
-describe('EventPipe', function() {
-  it('pipes all events from source to target', function(done) {
+describe('EventRelay', function() {
+  it('does not throw errors for an undefined source', function() {
+    var target = new stream.PassThrough();
+    var er = new EventRelay(undefined, target);
+    er.clear();
+    er.resume();
+  });
+
+  it('relays all events from source to target', function(done) {
     var source = new events.EventEmitter();
     var target = new stream.PassThrough();
-    var ep = new EventPipe(source, target);
+    var er = new EventRelay(source, target);
 
     // send events
     var sentEvents = ['one', 'two', 'three'];
@@ -48,20 +55,51 @@ describe('EventPipe', function() {
         done();
       });
 
-    ep.resume(); // note EventPipe starts in 'paused' mode
+    er.resume(); // note EventRelay starts in 'paused' mode
   });
 
-  it('clears events and only pipes new events from source to target', function(done) {
+  it('allows source to be defined after construction', function(done) {
     var source = new events.EventEmitter();
     var target = new stream.PassThrough();
-    var ep = new EventPipe(source, target);
+    var er = new EventRelay(target);
+
+    er.setSource(source);
+
+    // send events
+    var sentEvents = ['one', 'two', 'three'];
+    sentEvents.forEach(function(e) {
+      source.emit(e, e);
+    });
+
+    // add event handlers
+    var receivedEvents = [];
+    target
+      .on('one', function(x) {
+        receivedEvents.push(x);
+      })
+      .on('two', function(x) {
+        receivedEvents.push(x);
+      })
+      .on('three', function(x) {
+        receivedEvents.push(x);
+        assert.deepEqual(receivedEvents, sentEvents);
+        done();
+      });
+
+    er.resume(); // note EventRelay starts in 'paused' mode
+  });
+
+  it('clears events and only relays new events from source to target', function(done) {
+    var source = new events.EventEmitter();
+    var target = new stream.PassThrough();
+    var er = new EventRelay(source, target);
 
     // send events
     ['one', 'two', 'three'].forEach(function(e) {
       source.emit(e, e);
     });
 
-    ep.clear();
+    er.clear();
 
     // send more events
     var sentEvents = ['four', 'five', 'six'];
@@ -84,13 +122,13 @@ describe('EventPipe', function() {
         done();
       });
 
-    ep.resume(); // note EventPipe starts in 'paused' mode
+    er.resume(); // note EventRelay starts in 'paused' mode
   });
 
-  it('pipes data from source to target', function(done) {
+  it('relays data from source to target', function(done) {
     var source = new events.EventEmitter();
     var target = new stream.PassThrough();
-    var ep = new EventPipe(source, target);
+    var er = new EventRelay(source, target);
 
     source.emit('request', {url: 'http://localhost:5986'});
     source.emit('socket', {encrypted: true});
@@ -107,6 +145,7 @@ describe('EventPipe', function() {
     var data = [];
     var seenRequestEvent = false;
     var seenSocketEvent = false;
+    var seenResponseEvent = false;
 
     // add event handlers
     target
@@ -118,6 +157,10 @@ describe('EventPipe', function() {
         seenSocketEvent = true;
         assert.ok(socket.encrypted);
       })
+      .on('response', function(resp) {
+        seenResponseEvent = true;
+        assert.equal(resp.statusCode, 123);
+      })
       .on('pipe', function(src) {
         assert.fail('Unexpected "pipe" event received.');
       })
@@ -127,20 +170,28 @@ describe('EventPipe', function() {
       .on('end', function() {
         assert.ok(seenRequestEvent);
         assert.ok(seenSocketEvent);
+        assert.ok(seenResponseEvent);
         assert.deepEqual(data, sentData);
         done();
       });
 
-    ep.resume(); // note EventPipe starts in 'paused' mode
+    er.resume(); // note EventRelay starts in 'paused' mode
   });
 
-  it('pipes data from source to target (with `pipeData` enabled)', function(done) {
+  it('pipes data from source to target', function(done) {
     var source = new stream.Readable();
-
     source._read = function() {}; // noop read
-
     var target = new stream.PassThrough();
-    var ep = new EventPipe(source, target, true);
+
+    var er = new EventRelay(source, target);
+
+    var reader = new stream.PassThrough();
+    reader.data = [];
+    reader.on('data', function(data) {
+      reader.data.push(data.toString('utf8'));
+    });
+
+    target.pipe(reader); // pipe to reader
 
     source.emit('request', {url: 'http://localhost:5986'});
     source.emit('socket', {encrypted: true});
@@ -154,9 +205,9 @@ describe('EventPipe', function() {
 
     source.push(null); // signal EOF
 
-    var data = [];
     var seenRequestEvent = false;
     var seenSocketEvent = false;
+    var seenResponseEvent = false;
     var seenPipeEvent = false;
 
     // add event handlers
@@ -169,21 +220,23 @@ describe('EventPipe', function() {
         seenSocketEvent = true;
         assert.ok(socket.encrypted);
       })
+      .on('response', function(resp) {
+        seenResponseEvent = true;
+        assert.equal(resp.statusCode, 123);
+      })
       .on('pipe', function(src) {
         seenPipeEvent = true;
         assert.equal(typeof src, 'object');
       })
-      .on('data', function(d) {
-        data.push(d.toString('utf8'));
-      })
       .on('end', function() {
         assert.ok(seenRequestEvent);
         assert.ok(seenSocketEvent);
+        assert.ok(seenResponseEvent);
         assert.ok(seenPipeEvent);
-        assert.deepEqual(data, sentData);
+        assert.deepEqual(reader.data, sentData);
         done();
       });
 
-    ep.resume(); // note EventPipe starts in 'paused' mode
+    er.resume(); // note EventRelay starts in 'paused' mode
   });
 });

--- a/test/plugins/cookieauth.js
+++ b/test/plugins/cookieauth.js
@@ -92,6 +92,7 @@ describe('CookieAuth Plugin', function() {
         if (!process.env.NOCK_OFF) {
           assert.equal(resp.request.headers.cookie, MOCK_COOKIE);
         }
+        assert.equal(resp.request.uri.auth, null);
         assert.equal(resp.statusCode, 200);
         assert.ok(data.indexOf('"doc_count":0') > -1);
         mocks.done();
@@ -121,6 +122,7 @@ describe('CookieAuth Plugin', function() {
         if (!process.env.NOCK_OFF) {
           assert.equal(resp.request.headers.cookie, MOCK_COOKIE);
         }
+        assert.equal(resp.request.uri.auth, null);
         assert.equal(resp.statusCode, 200);
         assert.ok(data.indexOf('"doc_count":0') > -1);
 
@@ -136,6 +138,7 @@ describe('CookieAuth Plugin', function() {
         if (!process.env.NOCK_OFF) {
           assert.equal(resp.request.headers.cookie, MOCK_COOKIE);
         }
+        assert.equal(resp.request.uri.auth, null);
         assert.equal(resp.statusCode, 200);
         assert.ok(data.indexOf('"doc_count":0') > -1);
 
@@ -167,6 +170,7 @@ describe('CookieAuth Plugin', function() {
         cloudantClient.request(req, function(err, resp, data) {
           assert.equal(err, null);
           assert.equal(typeof resp.request.headers.cookie, 'undefined');
+          assert.equal(resp.request.uri.auth, null);
           assert.equal(resp.statusCode, 200);
           assert.ok(data.indexOf('"couchdb":"Welcome"') > -1);
           mocks.done();
@@ -195,6 +199,7 @@ describe('CookieAuth Plugin', function() {
         if (!process.env.NOCK_OFF) {
           assert.equal(resp.request.headers.cookie, MOCK_COOKIE);
         }
+        assert.equal(resp.request.uri.auth, null);
         assert.equal(resp.statusCode, 200);
         assert.ok(data.indexOf('"doc_count":0') > -1);
         mocks.done();
@@ -266,6 +271,7 @@ describe('CookieAuth Plugin', function() {
         if (!process.env.NOCK_OFF) {
           assert.equal(resp.request.headers.cookie, MOCK_COOKIE);
         }
+        assert.equal(resp.request.uri.auth, null);
         assert.equal(resp.statusCode, 200);
         assert.ok(data.indexOf('"doc_count":0') > -1);
         mocks.done();
@@ -293,6 +299,7 @@ describe('CookieAuth Plugin', function() {
         if (!process.env.NOCK_OFF) {
           assert.equal(resp.request.headers.cookie, MOCK_COOKIE);
         }
+        assert.equal(resp.request.uri.auth, null);
         assert.equal(resp.statusCode, 200);
         assert.ok(data.indexOf('"doc_count":0') > -1);
         mocks.done();
@@ -354,6 +361,7 @@ describe('CookieAuth Plugin', function() {
           cloudantClient.request(req2, function(err, resp, data) {
             assert.equal(err, null);
             assert.equal(resp.request.headers.cookie, MOCK_COOKIE);
+            assert.equal(resp.request.uri.auth, null);
             assert.equal(resp.statusCode, 200);
             assert.ok(data.indexOf('"doc_count":0') > -1);
             mocks.done();
@@ -382,6 +390,7 @@ describe('CookieAuth Plugin', function() {
       cloudantClient.request(req, function(err, resp, data) {
         assert.equal(err, null);
         assert.equal(resp.request.headers.cookie, MOCK_COOKIE);
+        assert.equal(resp.request.uri.auth, null);
         assert.equal(resp.statusCode, 200);
         assert.ok(data.indexOf('"doc_count":0') > -1);
         mocks.done();
@@ -409,6 +418,7 @@ describe('CookieAuth Plugin', function() {
       cloudantClient.request(req, function(err, resp, data) {
         assert.equal(err, null);
         assert.equal(resp.request.headers.cookie, MOCK_COOKIE_2);
+        assert.equal(resp.request.uri.auth, null);
         assert.equal(resp.statusCode, 200);
         assert.ok(data.indexOf('"doc_count":0') > -1);
         mocks.done();
@@ -440,6 +450,7 @@ describe('CookieAuth Plugin', function() {
           if (!process.env.NOCK_OFF) {
             assert.equal(resp.request.headers.cookie, MOCK_COOKIE);
           }
+          assert.equal(resp.request.uri.auth, null);
           assert.equal(resp.statusCode, 200);
         })
         .on('data', function(data) {
@@ -483,6 +494,7 @@ describe('CookieAuth Plugin', function() {
           if (!process.env.NOCK_OFF) {
             assert.equal(resp.request.headers.cookie, MOCK_COOKIE);
           }
+          assert.equal(resp.request.uri.auth, null);
           assert.equal(resp.statusCode, 200);
         })
         .on('data', function(data) {
@@ -508,6 +520,7 @@ describe('CookieAuth Plugin', function() {
           if (!process.env.NOCK_OFF) {
             assert.equal(resp.request.headers.cookie, MOCK_COOKIE);
           }
+          assert.equal(resp.request.uri.auth, null);
           assert.equal(resp.statusCode, 200);
         })
         .on('data', function(data) {
@@ -554,6 +567,7 @@ describe('CookieAuth Plugin', function() {
             if (!process.env.NOCK_OFF) {
               assert.equal(typeof resp.request.headers.cookie, 'undefined');
             }
+            assert.equal(resp.request.uri.auth, null);
             assert.equal(resp.statusCode, 200);
           })
           .on('data', function(data) {
@@ -596,6 +610,7 @@ describe('CookieAuth Plugin', function() {
           if (!process.env.NOCK_OFF) {
             assert.equal(resp.request.headers.cookie, MOCK_COOKIE);
           }
+          assert.equal(resp.request.uri.auth, null);
           assert.equal(resp.statusCode, 200);
         })
         .on('data', function(data) {
@@ -702,6 +717,7 @@ describe('CookieAuth Plugin', function() {
           if (!process.env.NOCK_OFF) {
             assert.equal(resp.request.headers.cookie, MOCK_COOKIE);
           }
+          assert.equal(resp.request.uri.auth, null);
           assert.equal(resp.statusCode, 200);
         })
         .on('data', function(data) {
@@ -743,6 +759,7 @@ describe('CookieAuth Plugin', function() {
           if (!process.env.NOCK_OFF) {
             assert.equal(resp.request.headers.cookie, MOCK_COOKIE);
           }
+          assert.equal(resp.request.uri.auth, null);
           assert.equal(resp.statusCode, 200);
         })
         .on('data', function(data) {
@@ -843,6 +860,7 @@ describe('CookieAuth Plugin', function() {
                 if (!process.env.NOCK_OFF) {
                   assert.equal(resp.request.headers.cookie, MOCK_COOKIE);
                 }
+                assert.equal(resp.request.uri.auth, null);
                 assert.equal(resp.statusCode, 200);
               })
               .on('data', function(data) {
@@ -887,6 +905,7 @@ describe('CookieAuth Plugin', function() {
           if (!process.env.NOCK_OFF) {
             assert.equal(resp.request.headers.cookie, MOCK_COOKIE);
           }
+          assert.equal(resp.request.uri.auth, null);
           assert.equal(resp.statusCode, 200);
         })
         .on('data', function(data) {
@@ -930,6 +949,7 @@ describe('CookieAuth Plugin', function() {
           if (!process.env.NOCK_OFF) {
             assert.equal(resp.request.headers.cookie, MOCK_COOKIE_2);
           }
+          assert.equal(resp.request.uri.auth, null);
           assert.equal(resp.statusCode, 200);
         })
         .on('data', function(data) {
@@ -964,6 +984,7 @@ describe('CookieAuth Plugin', function() {
         if (!process.env.NOCK_OFF) {
           assert.equal(resp.request.headers.cookie, MOCK_COOKIE);
         }
+        assert.equal(resp.request.uri.auth, null);
         assert.equal(resp.statusCode, 200);
         assert.ok(data.indexOf('"doc_count":0') > -1);
       })
@@ -975,6 +996,7 @@ describe('CookieAuth Plugin', function() {
           if (!process.env.NOCK_OFF) {
             assert.equal(resp.request.headers.cookie, MOCK_COOKIE);
           }
+          assert.equal(resp.request.uri.auth, null);
           assert.equal(resp.statusCode, 200);
         })
         .on('data', function(data) {
@@ -1012,6 +1034,7 @@ describe('CookieAuth Plugin', function() {
         cloudantClient.request(req, function(err, resp, data) {
           assert.equal(err, null);
           assert.equal(typeof resp.request.headers.cookie, 'undefined');
+          assert.equal(resp.request.uri.auth, null);
           assert.equal(resp.statusCode, 200);
           assert.ok(data.indexOf('"couchdb":"Welcome"') > -1);
         })
@@ -1021,6 +1044,7 @@ describe('CookieAuth Plugin', function() {
           .on('response', function(resp) {
             responseCount++;
             assert.equal(typeof resp.request.headers.cookie, 'undefined');
+            assert.equal(resp.request.uri.auth, null);
             assert.equal(resp.statusCode, 200);
           })
           .on('data', function(data) {
@@ -1059,6 +1083,7 @@ describe('CookieAuth Plugin', function() {
         if (!process.env.NOCK_OFF) {
           assert.equal(resp.request.headers.cookie, MOCK_COOKIE);
         }
+        assert.equal(resp.request.uri.auth, null);
         assert.equal(resp.statusCode, 200);
         assert.ok(data.indexOf('"doc_count":0') > -1);
       })
@@ -1070,6 +1095,7 @@ describe('CookieAuth Plugin', function() {
           if (!process.env.NOCK_OFF) {
             assert.equal(resp.request.headers.cookie, MOCK_COOKIE);
           }
+          assert.equal(resp.request.uri.auth, null);
           assert.equal(resp.statusCode, 200);
         })
         .on('data', function(data) {
@@ -1180,6 +1206,7 @@ describe('CookieAuth Plugin', function() {
         if (!process.env.NOCK_OFF) {
           assert.equal(resp.request.headers.cookie, MOCK_COOKIE);
         }
+        assert.equal(resp.request.uri.auth, null);
         assert.equal(resp.statusCode, 200);
         assert.ok(data.indexOf('"doc_count":0') > -1);
       })
@@ -1191,6 +1218,7 @@ describe('CookieAuth Plugin', function() {
           if (!process.env.NOCK_OFF) {
             assert.equal(resp.request.headers.cookie, MOCK_COOKIE);
           }
+          assert.equal(resp.request.uri.auth, null);
           assert.equal(resp.statusCode, 200);
         })
         .on('data', function(data) {
@@ -1228,6 +1256,7 @@ describe('CookieAuth Plugin', function() {
         if (!process.env.NOCK_OFF) {
           assert.equal(resp.request.headers.cookie, MOCK_COOKIE);
         }
+        assert.equal(resp.request.uri.auth, null);
         assert.equal(resp.statusCode, 200);
         assert.ok(data.indexOf('"doc_count":0') > -1);
       })
@@ -1239,6 +1268,7 @@ describe('CookieAuth Plugin', function() {
           if (!process.env.NOCK_OFF) {
             assert.equal(resp.request.headers.cookie, MOCK_COOKIE);
           }
+          assert.equal(resp.request.uri.auth, null);
           assert.equal(resp.statusCode, 200);
         })
         .on('data', function(data) {
@@ -1341,6 +1371,7 @@ describe('CookieAuth Plugin', function() {
             cloudantClient.request(req2, function(err, resp, data) {
               assert.equal(err, null);
               assert.equal(resp.request.headers.cookie, MOCK_COOKIE);
+              assert.equal(resp.request.uri.auth, null);
               assert.equal(resp.statusCode, 200);
               assert.ok(data.indexOf('"doc_count":0') > -1);
             })
@@ -1352,6 +1383,7 @@ describe('CookieAuth Plugin', function() {
                 if (!process.env.NOCK_OFF) {
                   assert.equal(resp.request.headers.cookie, MOCK_COOKIE);
                 }
+                assert.equal(resp.request.uri.auth, null);
                 assert.equal(resp.statusCode, 200);
               })
               .on('data', function(data) {
@@ -1392,6 +1424,7 @@ describe('CookieAuth Plugin', function() {
         if (!process.env.NOCK_OFF) {
           assert.equal(resp.request.headers.cookie, MOCK_COOKIE);
         }
+        assert.equal(resp.request.uri.auth, null);
         assert.equal(resp.statusCode, 200);
         assert.ok(data.indexOf('"doc_count":0') > -1);
       })
@@ -1403,6 +1436,7 @@ describe('CookieAuth Plugin', function() {
           if (!process.env.NOCK_OFF) {
             assert.equal(resp.request.headers.cookie, MOCK_COOKIE);
           }
+          assert.equal(resp.request.uri.auth, null);
           assert.equal(resp.statusCode, 200);
         })
         .on('data', function(data) {
@@ -1442,6 +1476,7 @@ describe('CookieAuth Plugin', function() {
         if (!process.env.NOCK_OFF) {
           assert.equal(resp.request.headers.cookie, MOCK_COOKIE);
         }
+        assert.equal(resp.request.uri.auth, null);
         assert.equal(resp.statusCode, 200);
         assert.ok(data.indexOf('"doc_count":0') > -1);
       })
@@ -1453,6 +1488,7 @@ describe('CookieAuth Plugin', function() {
           if (!process.env.NOCK_OFF) {
             assert.equal(resp.request.headers.cookie, MOCK_COOKIE_2);
           }
+          assert.equal(resp.request.uri.auth, null);
           assert.equal(resp.statusCode, 200);
         })
         .on('data', function(data) {


### PR DESCRIPTION
## What
Support legacy custom plugins.

Includes a couple of additional patches highlighted in testing, namely:
- Remove URL credentials when using cookie authentication.
- Add missing `request.abort()` hook.