### PR TITLE
Allow custom service name in CloudFoundry VCAP_SERVICES env var

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,8 @@
   for Cloudant on IBM Cloud. Note: IAM API key support is not yet enabled in the
   service.
 - [NEW] Support multiple plugins. See 'api-migration.md' for migration details.
+- [NEW] Allow custom service name in CloudFoundry VCAP_SERVICES environment
+  variable.
 - [IMPROVED] Updated documentation by replacing deprecated Cloudant links with
   the latest bluemix.net links.
 

--- a/README.md
+++ b/README.md
@@ -145,14 +145,16 @@ var Cloudant = require('cloudant')
 var cloudant = Cloudant("https://MYUSERNAME:MYPASSWORD@MYACCOUNT.cloudant.com");
 ~~~
 
-Running on Bluemix? You can initialize Cloudant directly from the `VCAP_SERVICES` environment variable:
+Running on Bluemix? You can initialize Cloudant directly from the `VCAP_SERVICES` environment variable. Just pass `vcapServices` and your `vcapInstanceName` (or alias `instanceName`) in the client configuration:
 
 ~~~ js
 var Cloudant = require('cloudant');
-var cloudant = Cloudant({instanceName: 'foo', vcapServices: JSON.parse(process.env.VCAP_SERVICES)});
+var cloudant = Cloudant({ vcapInstanceName: 'foo', vcapServices: JSON.parse(process.env.VCAP_SERVICES) });
 ~~~
 
-Note, if you only have a single Cloudant service then specifying the `instanceName` isn't required.
+You can also specify a `vcapServiceName` if your service name isn't the default, namely 'cloudantNoSQLDB'.
+
+Note, if you only have a single Cloudant service then specifying the `vcapInstanceName` isn't required.
 
 You can optionally provide a callback to the Cloudant initialization function. This will make the library automatically "ping" Cloudant to confirm the connection and that your credentials work.
 

--- a/lib/reconfigure.js
+++ b/lib/reconfigure.js
@@ -61,14 +61,23 @@ module.exports = function(config) {
 
     outUrl = config.url;
   } else if (config.vcapServices) {
-    var cloudantServices = config.vcapServices.cloudantNoSQLDB;
+    var cloudantServices;
+    if (typeof config.vcapServiceName !== 'undefined') {
+      cloudantServices = config.vcapServices[config.vcapServiceName];
+    } else {
+      cloudantServices = config.vcapServices.cloudantNoSQLDB;
+    }
 
     if (!cloudantServices || cloudantServices.length === 0) {
       throw new Error('Missing Cloudant service in vcapServices');
     }
 
+    if (typeof config.vcapInstanceName !== 'undefined') {
+      config.instanceName = config.vcapInstanceName; // alias
+    }
+
     for (var i = 0; i < cloudantServices.length; i++) {
-      if (config.instanceName === undefined || cloudantServices[i].name === config.instanceName) {
+      if (typeof config.instanceName === 'undefined' || cloudantServices[i].name === config.instanceName) {
         var credentials = cloudantServices[i].credentials;
         if (credentials && credentials.url) {
           outUrl = credentials.url;

--- a/test/legacy/reconfigure.js
+++ b/test/legacy/reconfigure.js
@@ -141,6 +141,31 @@ describe('Reconfigure', function() {
     done();
   });
 
+  it('gets URL by instance name alias from vcap containing single service', function(done) {
+    var config = { vcapInstanceName: 'serviceA', // alias of 'instanceName'
+      vcapServices: { cloudantNoSQLDB: [
+        { name: 'serviceA', credentials: { url: 'http://mykey:mypassword@mydomain.cloudant.com' } }
+      ]}
+    };
+    var url = reconfigure(config);
+    url.should.be.a.String;
+    url.should.equal('http://mykey:mypassword@mydomain.cloudant.com');
+    done();
+  });
+
+  it('gets URL by service name and instance name from vcap containing single service', function(done) {
+    var config = {
+      vcapServiceName: 'myNoSQLDB', vcapInstanceName: 'instanceA',
+      vcapServices: { myNoSQLDB: [
+        { name: 'instanceA', credentials: { url: 'http://mykey:mypassword@mydomain.cloudant.com' } }
+      ]}
+    };
+    var url = reconfigure(config);
+    url.should.be.a.String;
+    url.should.equal('http://mykey:mypassword@mydomain.cloudant.com');
+    done();
+  });
+
   it('gets first URL from vcap containing multiple services', function(done) {
     var config = {vcapServices: {cloudantNoSQLDB: [
       {credentials: {url: 'http://mykey:mypassword@mydomain.cloudant.com'}},


### PR DESCRIPTION
Thanks for your hard work, please ensure all items are complete before opening.

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://github.com/cloudant/nodejs-cloudant/blob/master/DCO1.1.txt)
- [x] You have added tests for any code changes
- [x] You have updated the [CHANGES.md](https://github.com/cloudant/nodejs-cloudant/blob/master/CHANGES.md)
- [x] You have completed the PR template below:

## What
Allow custom service name in CloudFoundry `VCAP_SERVICES` env var.

## How
Override default using `config.vcapServiceName`.

## Testing
Includes additional unit tests.

## Issues
Fixes #246.