### PR TITLE
Support piping of request payload

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@
 - [NEW] Allow custom service name in CloudFoundry VCAP_SERVICES environment
   variable.
 - [FIXED] Fix `get_security`/`set_security` asymmetry.
+- [FIXED] Support piping of request payload.
 - [IMPROVED] Updated documentation by replacing deprecated Cloudant links with
   the latest bluemix.net links.
 - [REMOVED] Remove previously deprecated method `set_permissions`.

--- a/lib/client.js
+++ b/lib/client.js
@@ -1,4 +1,4 @@
-// Copyright © 2017 IBM Corp. All rights reserved.
+// Copyright © 2017, 2018 IBM Corp. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,8 +16,8 @@
 const async = require('async');
 const debug = require('debug')('cloudant:client');
 const EventRelay = require('./eventrelay.js');
+const PassThroughDuplex = require('./passthroughduplex.js');
 const pkg = require('../package.json');
-const stream = require('stream');
 const utils = require('./clientutils.js');
 
 const DEFAULTS = {
@@ -160,9 +160,14 @@ class CloudantClient {
     var request = {};
     request.abort = false;
     request.clientCallback = callback;
-    request.clientStream = new stream.PassThrough();
+
+    request.clientStream = new PassThroughDuplex();
     request.clientStream.on('error', function(err) {
       debug(err);
+    });
+    request.clientStream.on('pipe', function() {
+      debug('Request body is being piped.');
+      request.pipedRequest = true;
     });
 
     request.eventRelay = new EventRelay(request.clientStream);
@@ -192,13 +197,6 @@ class CloudantClient {
       // monkey-patched with `request.abort()`.
       request.abort = true;
     };
-
-    var noClientCallback = typeof request.clientCallback === 'undefined';
-
-    if (!noClientCallback) {
-      // disable event piping if the client has specified a callback
-      request.eventRelay.disablePiping();
-    }
 
     async.forever(function(done) {
       request.options = Object.assign({}, options); // new copy
@@ -238,20 +236,29 @@ class CloudantClient {
             request.response = self._client(
               request.options, utils.wrapCallback(request, done));
 
+            if (request.pipedRequest) {
+              request.clientStream.passThroughWritable.pipe(request.response);
+            }
+
             // define new source on event relay
             request.eventRelay.setSource(request.response);
 
-            if (noClientCallback) {
-              // run hooks using response event listener
+            request.response.pipe(request.clientStream.passThroughReadable);
+
+            request.response
+              .on('response', function(response) {
+                request.response.pause();
+                utils.runHooks('onResponse', request, response, function() {
+                  utils.processState(request, done); // process response hook results
+                });
+              });
+
+            if (typeof request.clientCallback === 'undefined') {
+              debug('Running error hook using event handler.');
               request.response
                 .on('error', function(error) {
                   utils.runHooks('onError', request, error, function() {
                     utils.processState(request, done); // process error hook results
-                  });
-                })
-                .on('response', function(response) {
-                  utils.runHooks('onResponse', request, response, function() {
-                    utils.processState(request, done); // process response hook results
                   });
                 });
             }

--- a/lib/clientutils.js
+++ b/lib/clientutils.js
@@ -1,4 +1,4 @@
-// Copyright © 2017 IBM Corp. All rights reserved.
+// Copyright © 2017, 2018 IBM Corp. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -103,6 +103,7 @@ var processState = function(r, callback) {
         // pass response through to awaiting client
         r.eventRelay.resume();
       }
+      r.response.resume();
       callback(new Error('No retry requested')); // no retry
     }
   }
@@ -128,32 +129,26 @@ var runHooks = function(hookName, r, data, end) {
   }
 };
 
-// wrap client callback to allow for plugin hook execution
+// wrap client callback to allow for plugin error hook execution
 var wrapCallback = function(r, done) {
   if (typeof r.clientCallback === 'undefined') {
-    debug('Running hooks using response event listener');
     return undefined; // noop
   } else {
-    debug('Running hooks using wrapped client callback.');
+    debug('Running error hook using wrapped client callback.');
     // return wrapped callback
     return function(error, response, body) {
-      var cb = function() {
-        processState(r, function(stop) {
-          if (stop) {
-            if (!stop.skipClientCallback) {
-              debug('Running client callback...');
+      if (error) {
+        runHooks('onError', r, error, function() {
+          processState(r, function(stop) {
+            if (stop && !stop.skipClientCallback) {
               r.clientCallback(error, response, body);
             }
             done(stop);
-          } else {
-            done();
-          }
+          });
         });
-      };
-      if (error) {
-        runHooks('onError', r, error, cb);
       } else {
-        runHooks('onResponse', r, response, cb);
+        r.clientCallback(error, response, body);
+        // execute `done()` in response hook
       }
     };
   }

--- a/lib/eventrelay.js
+++ b/lib/eventrelay.js
@@ -1,4 +1,4 @@
-// Copyright © 2017 IBM Corp. All rights reserved.
+// Copyright © 2017, 2018 IBM Corp. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -26,109 +26,57 @@ class EventRelay {
     var self = this;
 
     if (typeof target === 'undefined') {
-      target = source;
-      source = {};
+      self._target = source;
+    } else {
+      self._target = target;
+      self.setSource(source);
     }
 
-    self.setSource(source || {});
-    self._target = target;
-
-    self._disablePiping = false;
-    self._eventsStash = [];
     self._paused = true;
-    self._pipeData = false; // default
-
-    // monkey-patch the target pipe function
-    var oldPipe = self._target.pipe;
-    self._target.pipe = function() {
-      debug('Target stream is being piped.');
-      self._pipeData = true;
-      return oldPipe.apply(self._target, arguments);
-    };
-  }
-
-  // Set a new source event emitter.
-  setSource(source) {
-    var self = this;
-
-    if (typeof self._oldSourceEmit !== 'undefined') {
-      debug('Stopped listening to old source stream');
-      self._source.emit = self._oldSourceEmit;
-      self.clear();
-    }
-
-    debug('Setting new source stream.');
-    self._source = source;
-    if (typeof source === 'undefined') {
-      return;
-    }
-
-    // monkey-patch the source emit function
-    self._oldSourceEmit = self._source.emit;
-    self._source.emit = function() {
-      var args = arguments;
-      if (!self._disablePiping && self._pipeData) {
-        if (args[0] === 'response') {
-          // will resume flow when client calls `EventRelay.resume()`
-          debug('Received \'response\' event. Pausing source stream.');
-          self._source.pause();
-        } else if (args[0] === 'data' || args[0] === 'end') {
-          // don't emit on target as data is pushed via pipe
-          return self._oldSourceEmit.apply(self._source, arguments);
-        }
-      }
-      if (self._paused) {
-        self._eventsStash.push(args); // stash event
-      } else {
-        self._target.emit.apply(self._target, args);
-      }
-      self._oldSourceEmit.apply(self._source, arguments);
-    };
+    self._eventsStash = [];
   }
 
   // Clear all stashed events.
   clear() {
-    debug('Clearing all previously stashed events.');
     this._eventsStash = [];
-  }
-
-  // Disable event piping.
-  disablePiping() {
-    debug('Disabling piping in event relay.');
-    this._disablePiping = true;
   }
 
   // Pause event relay.
   pause() {
-    debug('Pausing event relay.');
     this._paused = true;
   }
 
   // Resume event relay and fire all stashed events.
   resume() {
     var self = this;
-    self._paused = false;
+
+    this._paused = false;
 
     debug('Relaying captured events to target stream.');
-
-    if (!self._disablePiping && self._pipeData) {
-      debug('Piping data from source to target.');
-      self._source.pipe(self._target);
-      self._source.resume();
-    } else {
-      debug('Target stream is not being piped.');
-    }
-
-    var eventNames;
-    if (typeof self._target.eventNames !== 'undefined') {
-      eventNames = self._target.eventNames();
-    }
-
     self._eventsStash.forEach(function(event) {
-      if (typeof eventNames === 'undefined' || eventNames.indexOf(event[0]) !== -1) {
-        self._target.emit.apply(self._target, event);
-      }
+      self._target.emit.apply(self._target, event);
     });
+  }
+
+  // Set a new source event emitter.
+  setSource(source) {
+    var self = this;
+
+    self.clear();
+    self.pause();
+
+    debug('Setting new source stream.');
+    self._source = source;
+
+    self._oldEmit = self._source.emit;
+    self._source.emit = function() {
+      if (self._paused) {
+        self._eventsStash.push(arguments);
+      } else {
+        self._target.emit.apply(self._target, arguments);
+      }
+      self._oldEmit.apply(self._source, arguments);
+    };
   }
 }
 

--- a/lib/passthroughduplex.js
+++ b/lib/passthroughduplex.js
@@ -1,0 +1,127 @@
+// Copyright © 2018 IBM Corp. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+'use strict';
+
+const stream = require('stream');
+
+class PassThroughDuplex extends stream.Duplex {
+  constructor(options) {
+    super(options);
+
+    this.passThroughReadable = new stream.PassThrough();
+    this.passThroughReadable.on('error', function(error) {
+      this.emit(error);
+    });
+
+    this.passThroughWritable = new stream.PassThrough();
+    this.passThroughWritable.on('error', function(error) {
+      this.emit(error);
+    });
+  }
+
+  // readable
+
+  _read(size) {
+    return this.passThroughReadable._read(size);
+  }
+
+  isPaused() {
+    return this.passThroughReadable.isPaused();
+  }
+
+  pause() {
+    return this.passThroughReadable.pause();
+  }
+
+  pipe(destination, options) {
+    return this.passThroughReadable.pipe(destination, options);
+  }
+
+  readableHighWaterMark() {
+    return this.passThroughReadable.readableHighWaterMark();
+  }
+
+  read(size) {
+    return this.passThroughReadable.read(size);
+  }
+
+  resume() {
+    return this.passThroughReadable.resume();
+  }
+
+  setEncoding(encoding) {
+    return this.passThroughReadable.setEncoding(encoding);
+  }
+
+  unpipe(destination) {
+    return this.passThroughReadable.unpipe(destination);
+  }
+
+  unshift(chunk) {
+    return this.passThroughReadable.unshift(chunk);
+  }
+
+  wrap(stream) {
+    return this.passThroughReadable.wrap(stream);
+  }
+
+  // writable
+
+  _final(callback) {
+    return this.passThroughWritable._final(callback);
+  }
+
+  _write(chunk, encoding, callback) {
+    return this.passThroughWritable._write(chunk, encoding, callback);
+  }
+
+  _writev(chunks, callback) {
+    return this.passThroughWritable._writev(chunks, callback);
+  }
+
+  cork() {
+    return this.passThroughWritable.cork();
+  }
+
+  end(chunk, encoding, callback) {
+    return this.passThroughWritable.end(chunk, encoding, callback);
+  }
+
+  setDefaultEncoding(encoding) {
+    return this.passThroughWritable.setDefaultEncoding(encoding);
+  }
+
+  uncork() {
+    return this.passThroughWritable.uncork();
+  }
+
+  writableHighWaterMark() {
+    return this.passThroughWritable.writableHighWaterMark();
+  }
+
+  write(chunk, encoding, callback) {
+    return this.passThroughWritable.write(chunk, encoding, callback);
+  }
+
+  // destroy
+
+  destroy(error) {
+    this.passThroughWritable.destroy(error);
+    this.passThroughReadable.destroy(error);
+  }
+}
+
+PassThroughDuplex.addListener = PassThroughDuplex.on;
+
+module.exports = PassThroughDuplex;

--- a/test/eventrelay.js
+++ b/test/eventrelay.js
@@ -1,4 +1,4 @@
-// Copyright © 2017 IBM Corp. All rights reserved.
+// Copyright © 2017, 2018 IBM Corp. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@ const EventRelay = require('../lib/eventrelay.js');
 describe('EventRelay', function() {
   it('does not throw errors for an undefined source', function() {
     var target = new stream.PassThrough();
-    var er = new EventRelay(undefined, target);
+    var er = new EventRelay(target);
     er.clear();
     er.resume();
   });
@@ -125,7 +125,7 @@ describe('EventRelay', function() {
     er.resume(); // note EventRelay starts in 'paused' mode
   });
 
-  it('relays data from source to target', function(done) {
+  it('relays request events from source to target', function(done) {
     var source = new events.EventEmitter();
     var target = new stream.PassThrough();
     var er = new EventRelay(source, target);
@@ -172,68 +172,6 @@ describe('EventRelay', function() {
         assert.ok(seenSocketEvent);
         assert.ok(seenResponseEvent);
         assert.deepEqual(data, sentData);
-        done();
-      });
-
-    er.resume(); // note EventRelay starts in 'paused' mode
-  });
-
-  it('pipes data from source to target', function(done) {
-    var source = new stream.Readable();
-    source._read = function() {}; // noop read
-    var target = new stream.PassThrough();
-
-    var er = new EventRelay(source, target);
-
-    var reader = new stream.PassThrough();
-    reader.data = [];
-    reader.on('data', function(data) {
-      reader.data.push(data.toString('utf8'));
-    });
-
-    target.pipe(reader); // pipe to reader
-
-    source.emit('request', {url: 'http://localhost:5986'});
-    source.emit('socket', {encrypted: true});
-    source.emit('response', {statusCode: 123});
-
-    // data
-    var sentData = ['foo', 'bar', 'baz'];
-    sentData.forEach(function(d) {
-      source.push(d);
-    });
-
-    source.push(null); // signal EOF
-
-    var seenRequestEvent = false;
-    var seenSocketEvent = false;
-    var seenResponseEvent = false;
-    var seenPipeEvent = false;
-
-    // add event handlers
-    target
-      .on('request', function(req) {
-        seenRequestEvent = true;
-        assert.equal(req.url, 'http://localhost:5986');
-      })
-      .on('socket', function(socket) {
-        seenSocketEvent = true;
-        assert.ok(socket.encrypted);
-      })
-      .on('response', function(resp) {
-        seenResponseEvent = true;
-        assert.equal(resp.statusCode, 123);
-      })
-      .on('pipe', function(src) {
-        seenPipeEvent = true;
-        assert.equal(typeof src, 'object');
-      })
-      .on('end', function() {
-        assert.ok(seenRequestEvent);
-        assert.ok(seenSocketEvent);
-        assert.ok(seenResponseEvent);
-        assert.ok(seenPipeEvent);
-        assert.deepEqual(reader.data, sentData);
         done();
       });
 

--- a/test/legacy/plugin.js
+++ b/test/legacy/plugin.js
@@ -1,4 +1,4 @@
-// Copyright © 2015, 2017 IBM Corp. All rights reserved.
+// Copyright © 2015, 2018 IBM Corp. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -26,7 +26,7 @@ var uuid = require('uuid/v4');
 var nock = require('../nock.js');
 var Cloudant = require('../../cloudant.js');
 var request = require('request');
-var stream = require('stream');
+var PassThroughDuplex = require('../../lib/passthroughduplex.js');
 
 // These globals may potentially be parameterized.
 var ME = process.env.cloudant_username || 'nodejs';
@@ -121,7 +121,7 @@ describe('retry-on-429 plugin', function() {
     var p = db.info(function() {
       done();
     });
-    assert.equal(p instanceof stream.PassThrough, true);
+    assert.equal(p instanceof PassThroughDuplex, true);
   });
 });
 
@@ -176,7 +176,7 @@ describe('cookieauth plugin', function() {
       mocks.done();
       done();
     });
-    assert.equal(p instanceof require('stream').PassThrough, true);
+    assert.equal(p instanceof PassThroughDuplex, true);
   });
 
   it('should authenticate before attempting API call', function(done) {
@@ -298,7 +298,7 @@ describe('custom plugin', function() {
   };
 
   var defaultPlugin = function(opts, callback) {
-    request(opts, callback);
+    return request(opts, callback);
   };
 
   it('should allow custom plugins', function(done) {

--- a/test/passthroughduplex.js
+++ b/test/passthroughduplex.js
@@ -1,0 +1,81 @@
+// Copyright © 2018 IBM Corp. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/* global describe it */
+'use strict';
+
+const assert = require('assert');
+const stream = require('stream');
+
+const PassThroughDuplex = require('../lib/passthroughduplex.js');
+
+describe('Pass Through Duplex', function() {
+  it('can write to internal writable', function(done) {
+    var duplex = new PassThroughDuplex();
+    var readable = new stream.Readable();
+    readable._read = function noop() {};
+
+    readable.pipe(duplex);
+
+    var data = ['data', 'some more data', 'even more data'];
+    data.forEach(function(d) {
+      readable.push(d);
+    });
+    readable.push(null);
+
+    var chunks = [];
+    duplex.passThroughWritable.on('data', function(chunk) {
+      chunks.push(chunk.toString());
+    });
+
+    duplex.passThroughWritable.on('end', function() {
+      assert.deepEqual(chunks, data);
+      done();
+    });
+  });
+
+  it('can read from internal readable', function(done) {
+    var duplex = new PassThroughDuplex();
+    var readable = new stream.Readable();
+    readable._read = function noop() {};
+
+    readable.pipe(duplex.passThroughReadable);
+
+    var data = ['data', 'some more data', 'even more data'];
+    data.forEach(function(d) {
+      readable.push(d);
+    });
+    readable.push(null);
+
+    var chunks = [];
+    duplex.passThroughReadable.on('data', function(chunk) {
+      chunks.push(chunk.toString());
+    });
+
+    duplex.passThroughReadable.on('end', function() {
+      assert.deepEqual(chunks, data);
+      done();
+    });
+  });
+
+  it('captures pipe event', function(done) {
+    var duplex = new PassThroughDuplex();
+
+    duplex.on('pipe', function() {
+      done();
+    });
+
+    process.stdin.pipe(duplex);
+  });
+});


### PR DESCRIPTION
Thanks for your hard work, please ensure all items are complete before opening.

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://github.com/cloudant/nodejs-cloudant/blob/master/DCO1.1.txt)
- [x] You have added tests for any code changes
- [x] You have updated the [CHANGES.md](https://github.com/cloudant/nodejs-cloudant/blob/master/CHANGES.md)
- [x] You have completed the PR template below:

## What
Support payload piping, for example:
```js
fs.createReadStream('keys.json').pipe(cloudant.request({ path: 'my_db/_all_docs', method: 'POST' }).pipe(process.stdout)
```
_Note:_ Additional work is required if these types of request are to be retried since currently the request stream may only be read once. This will be handled in a future PR.

## How
`cloudant.request` now returns a Duplex type which implements both Readable and Writable interfaces allowing both the request and response to be streamed.

## Testing
Includes additional unit tests.

## Issues
See #258.
