### PR TITLE
Setup request piping after events have been replayed

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,5 @@
 # 2.0.3 (UNRELEASED)
+- [NEW] Allow pipes to be defined inside request event handlers.
 
 # 2.0.2 (2018-02-14)
 - [FIXED] Updated `require` references to use newly scoped package

--- a/api-migration.md
+++ b/api-migration.md
@@ -18,28 +18,6 @@ The library continues to support legacy plugins. They can be used in conjunction
 with new plugins. Your plugins list may contain any number of new plugins but
 only ever one legacy plugin.
 
-The `cloudant.request` object is a duplex stream and cannot be used inside
-an event hook function. For example:
-
-```js
-var cloudant = new Cloudant({ url: myUrl, plugins: [ 'cookieauth', 'retry' ] });
-
-// make a custom request
-var r = cloudant.request({ path: '_all_dbs' })
-  .on('response', function(resp) {
-    if (resp.statusCode === 200) {
-      r.pipe(process.stdout); // this doesn't work!
-      resp.pipe(process.stdout); // this does work!
-    }
-  });
-
-r.pipe(process.stdout); // this does work!
-```
-
-The final response isn't returned to the client until all the plugin hooks have
-been executed. This means that any pipe on the `cloudant.request` object must be
-in place _before_ the `response` event is triggered (as shown above).
-
 If you were using the 429 `retry` plugin in version 1.x then be aware that
 the configuration has now changed. The new plugin retries 429 and 5xx HTTP
 status codes as well as any request errors (such as connection reset errors).

--- a/lib/client.js
+++ b/lib/client.js
@@ -335,10 +335,6 @@ class CloudantClient {
     // define new source on event relay
     request.eventRelay.setSource(request.response);
 
-    if (request.clientStream.destinations.length > 0) {
-      request.response.pipe(request.clientStream.passThroughReadable);
-    }
-
     request.response
       .on('response', function(response) {
         request.response.pause();

--- a/lib/clientutils.js
+++ b/lib/clientutils.js
@@ -103,6 +103,10 @@ var processState = function(r, callback) {
         // pass response through to awaiting client
         r.eventRelay.resume();
       }
+      if (r.clientStream.destinations.length > 0) {
+        // pipe response body to client stream
+        r.response.pipe(r.clientStream.passThroughReadable);
+      }
       r.response.resume();
       callback(new Error('No retry requested')); // no retry
     }

--- a/test/clientutils.js
+++ b/test/clientutils.js
@@ -95,7 +95,7 @@ describe('Client Utilities', function() {
           .get('/')
           .reply(200, {couchdb: 'Welcome'});
 
-      var r = { abort: false, clientStream: {}, response: request.get(SERVER) };
+      var r = { abort: false, clientStream: { destinations: [] }, response: request.get(SERVER) };
       r.state = {
         abortWithResponse: undefined,
         attempt: 3,
@@ -114,7 +114,7 @@ describe('Client Utilities', function() {
           .get('/')
           .reply(200, {couchdb: 'Welcome'});
 
-      var r = { abort: false, clientStream: {}, response: request.get(SERVER) };
+      var r = { abort: false, clientStream: { destinations: [] }, response: request.get(SERVER) };
       r.state = {
         abortWithResponse: undefined,
         attempt: 1,


### PR DESCRIPTION
This change allows pipes to be defined inside event handlers.

Thanks for your hard work, please ensure all items are complete before opening.

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://github.com/cloudant/nodejs-cloudant/blob/master/DCO1.1.txt)
- [x] You have added tests for any code changes
- [x] You have updated the [CHANGES.md](https://github.com/cloudant/nodejs-cloudant/blob/master/CHANGES.md)
- [x] You have completed the PR template below:

## What
Setup request piping after events have been replayed. This ensures we correctly pipe data where piping has been defined in an event handler.

## Testing
Includes additional unit tests.