### PR TITLE
Prepare 2.0.3 release

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,8 +1,8 @@
-# 2.0.3 (UNRELEASED)
-- [NEW] Add typescript definitions
+# 2.0.3 (2018-03-05)
+- [NEW] Add TypeScript definitions.
 - [NEW] Allow pipes to be defined inside request event handlers.
-- [NOTE] Update engines in preparation for Node.js 4 “Argon” end-of-life.
 - [UPGRADED] Using nano==6.4.3 dependancy.
+- [NOTE] Update engines in preparation for Node.js 4 “Argon” end-of-life.
 
 # 2.0.2 (2018-02-14)
 - [FIXED] Updated `require` references to use newly scoped package

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "type": "git",
     "url": "git@github.com:cloudant/nodejs-cloudant.git"
   },
-  "version": "2.0.3-SNAPSHOT",
+  "version": "2.0.3",
   "author": {
     "name": "IBM Cloudant",
     "email": "support@cloudant.com"


### PR DESCRIPTION
# 2.0.3 (2018-03-05)
- [NEW] Add TypeScript definitions.
- [NEW] Allow pipes to be defined inside request event handlers.
- [UPGRADED] Using nano==6.4.3 dependancy.
- [NOTE] Update engines in preparation for Node.js 4 “Argon” end-of-life.