### PR TITLE
Support Cloudant query when using promises request plugin

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 # UNRELEASED
 - [FIXED] Add missing `maxAttempt` parameter to TypeScript definition.
 - [FIXED] Removed test and lint data that bloated npm package size.
+- [FIXED] Support Cloudant query when using promises request plugin.
 
 # 2.1.0 (2018-03-05)
 - [NEW] Add TypeScript definitions.

--- a/cloudant.js
+++ b/cloudant.js
@@ -111,9 +111,9 @@ function Cloudant(options, callback) {
     // https://console.bluemix.net/docs/services/Cloudant/api/cloudant_query.html#query
     var index = function(definition, callback) {
       // if no definition is provided, then the user wants see all the indexes
-      if (typeof definition === 'function') {
+      if (typeof definition === 'function' || typeof definition === 'undefined') {
         callback = definition;
-        nano.request({ path: encodeURIComponent(db) + '/_index' }, callback);
+        return nano.request({ path: encodeURIComponent(db) + '/_index' }, callback);
       } else {
         // the user wants to create a new index
         return nano.request({ path: encodeURIComponent(db) + '/_index',

--- a/test/issues/292.js
+++ b/test/issues/292.js
@@ -1,0 +1,107 @@
+// Copyright © 2018 IBM Corp. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/* global describe it before after */
+'use strict';
+
+const assert = require('assert');
+const Client = require('../../lib/client.js');
+const Cloudant = require('../../cloudant.js');
+const nock = require('../nock.js');
+const uuidv4 = require('uuid/v4'); // random
+
+const ME = process.env.cloudant_username || 'nodejs';
+const PASSWORD = process.env.cloudant_password || 'sjedon';
+const SERVER = `https://${ME}.cloudant.com`;
+const DBNAME = `nodejs-cloudant-${uuidv4()}`;
+
+describe('Issue #292', function() {
+  before(function(done) {
+    var mocks = nock(SERVER)
+      .put(`/${DBNAME}`)
+      .reply(201, { ok: true });
+
+    var cloudantClient = new Client({ plugins: 'retry' });
+
+    var options = {
+      url: `${SERVER}/${DBNAME}`,
+      auth: { username: ME, password: PASSWORD },
+      method: 'PUT'
+    };
+    cloudantClient.request(options, function(err, resp) {
+      assert.equal(err, null);
+      assert.equal(resp.statusCode, 201);
+      mocks.done();
+      done();
+    });
+  });
+
+  after(function(done) {
+    var mocks = nock(SERVER)
+      .delete(`/${DBNAME}`)
+      .reply(200, { ok: true });
+
+    var cloudantClient = new Client({ plugins: 'retry' });
+
+    var options = {
+      url: `${SERVER}/${DBNAME}`,
+      auth: { username: ME, password: PASSWORD },
+      method: 'DELETE'
+    };
+    cloudantClient.request(options, function(err, resp) {
+      assert.equal(err, null);
+      assert.equal(resp.statusCode, 200);
+      mocks.done();
+      done();
+    });
+  });
+
+  it('lists all query indices using promise plugin', function(done) {
+    var mocks = nock(SERVER)
+      .get(`/${DBNAME}/_index`)
+      .reply(200, { total_rows: 1, indexes: [ { name: '_all_docs' } ] });
+
+    var cloudant = Cloudant({ account: ME, password: PASSWORD, plugins: 'promises' });
+    var db = cloudant.db.use(DBNAME);
+
+    db.index().then((d) => {
+      assert.equal(d.total_rows, 1);
+      mocks.done();
+      done();
+    })
+    .catch((err) => { assert.fail(`Unexpected error: ${err}`); });
+  });
+
+  it('creates new query index using promise plugin', function(done) {
+    var definition = {
+      index: { fields: [ 'foo' ] },
+      name: 'foo-index',
+      type: 'json'
+    };
+
+    var mocks = nock(SERVER)
+      .post(`/${DBNAME}/_index`, definition)
+      .reply(200, { result: 'created' });
+
+    var cloudant = Cloudant({ account: ME, password: PASSWORD, plugins: 'promises' });
+    var db = cloudant.db.use(DBNAME);
+
+    db.index(definition).then((d) => {
+      assert.equal(d.result, 'created');
+      mocks.done();
+      done();
+    })
+    .catch((err) => { assert.fail(`Unexpected error: ${err}`); });
+  });
+});


### PR DESCRIPTION
Thanks for your hard work, please ensure all items are complete before opening.

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://github.com/cloudant/nodejs-cloudant/blob/master/DCO1.1.txt)
- [x] You have added tests for any code changes
- [x] You have updated the [CHANGES.md](https://github.com/cloudant/nodejs-cloudant/blob/master/CHANGES.md)
- [x] You have completed the PR template below:

## What
Support Cloudant query when using promises request plugin.

## How

List all Cloudant NoSQL DB Query indexes:
```js
db.index().then((d) => { console.log(d); });
```

Creating an index:
```js
db.index(definition).then((d) => { console.log(d); })
```

## Testing
Includes additional unit tests.

## Issues
Fixes #292.