### PR TITLE
Remove ~15MB of test data from npm-published module

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -3,6 +3,7 @@
 # build tool config
 .travis.yml
 Jenkinsfile
+types/tsconfig.json
 
 # code examples
 example*
@@ -20,6 +21,8 @@ DCO1.1.txt
 
 # linters
 .eslintrc*
+.eslintignore
+types/tslint.json
 
 # npm
 .npmignore
@@ -29,6 +32,7 @@ DCO1.1.txt
 citest
 test*
 toxytests
+soak_tests
 
 # test logs
 *.log


### PR DESCRIPTION
Hello, PR #272 introduced ~15MB of soak test data that has been published to npm since v2.0.1.

This PR prevents the unnecessary publishing of this test data (and a couple of other development-only linter config files) to npm.

I've tested with `npm pack` to confirm this reduces the tarball size by ~97%.

Before:
```
1031561 cloudant-cloudant-2.2.0-SNAPSHOT.tgz
```
After:
```
30096 cloudant-cloudant-2.2.0-SNAPSHOT.tgz
```
