### PR TITLE
Prepare 2.2.0 release

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,4 @@
-# UNRELEASED
+# 2.2.0 (2018-04-30)
 - [FIXED] Add missing `maxAttempt` parameter to TypeScript definition.
 - [FIXED] Include client initialization callback in TypeScript definition.
 - [FIXED] Prevent client executing done callback multiple times.

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "type": "git",
     "url": "git@github.com:cloudant/nodejs-cloudant.git"
   },
-  "version": "2.2.0-SNAPSHOT",
+  "version": "2.2.0",
   "author": {
     "name": "IBM Cloudant",
     "email": "support@cloudant.com"


### PR DESCRIPTION
# 2.2.0 (2018-04-30)
- [FIXED] Add missing `maxAttempt` parameter to TypeScript definition.
- [FIXED] Include client initialization callback in TypeScript definition.
- [FIXED] Prevent client executing done callback multiple times.
- [FIXED] Removed test and lint data that bloated npm package size.
- [FIXED] Support Cloudant query when using promises request plugin.