### PR TITLE
Added support for IAM API key when initializing client with VCAP_SERVICES

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,5 @@
 # UNRELEASED
+- [IMPROVED] Added support for IAM API key when initializing client with VCAP_SERVICES environment variable.
 
 # 2.2.0 (2018-04-30)
 - [FIXED] Add missing `maxAttempt` parameter to TypeScript definition.

--- a/cloudant.js
+++ b/cloudant.js
@@ -1,4 +1,4 @@
-// Copyright © 2015, 2017 IBM Corp. All rights reserved.
+// Copyright © 2015, 2018 IBM Corp. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -33,17 +33,19 @@ function Cloudant(options, callback) {
     options = { url: options };
   }
 
-  var theurl = reconfigure(options);
-  if (theurl === null) {
+  var creds = reconfigure(options);
+  if (!creds || creds.outUrl === null) {
     var err = new Error('Invalid URL');
     if (callback) {
       return callback(err);
     } else {
       throw err;
     }
+  } else {
+    options.creds = creds;
   }
 
-  if (theurl.match(/^http:/)) {
+  if (creds.outUrl.match(/^http:/)) {
     options.https = false;
   }
 
@@ -53,7 +55,7 @@ function Cloudant(options, callback) {
     return cloudantClient.request(req, callback);
   };
 
-  var nanoOptions = { url: theurl, request: cloudantRequest, log: nanodebug };
+  var nanoOptions = { url: creds.outUrl, request: cloudantRequest, log: nanodebug };
   if (options.cookie) {
     nanoOptions.cookie = options.cookie; // legacy - sets 'X-CouchDB-WWW-Authenticate' header
   }

--- a/lib/client.js
+++ b/lib/client.js
@@ -47,7 +47,10 @@ class CloudantClient {
 
     // build plugin array
     var plugins = [];
-    if (typeof this._cfg.plugin === 'undefined' && typeof this._cfg.plugins === 'undefined') {
+    // If IAM key found in VCAP, add IAM plugin
+    if (self._cfg.creds && self._cfg.creds.iamApiKey) {
+      plugins.push({ iamauth: { iamApiKey: self._cfg.creds.iamApiKey } });
+    } else if (typeof this._cfg.plugin === 'undefined' && typeof this._cfg.plugins === 'undefined') {
       plugins = [ 'cookieauth' ]; // default
     } else {
       [].concat(self._cfg.plugins).forEach(function(plugin) {

--- a/lib/reconfigure.js
+++ b/lib/reconfigure.js
@@ -1,4 +1,4 @@
-// Copyright © 2015, 2017 IBM Corp. All rights reserved.
+// Copyright © 2015, 2018 IBM Corp. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -27,8 +27,8 @@ var url = require('url');
 
 module.exports = function(config) {
   config = JSON.parse(JSON.stringify(config)); // clone
-
   var outUrl;
+  var outCreds = {};
   // if a full URL is passed in
   if (config.url) {
     // parse the URL
@@ -39,7 +39,8 @@ module.exports = function(config) {
       parsed = null;
     }
     if (!config.url || !parsed || !parsed.hostname || !parsed.protocol || !parsed.slashes) {
-      return null;
+      outCreds.outUrl = null;
+      return outCreds;
     }
 
     // enforce HTTPS for *cloudant.com domains
@@ -58,7 +59,6 @@ module.exports = function(config) {
       // reconstruct the URL
       config.url = url.format(parsed);
     }
-
     outUrl = config.url;
   } else if (config.vcapServices) {
     var cloudantServices;
@@ -79,8 +79,11 @@ module.exports = function(config) {
     for (var i = 0; i < cloudantServices.length; i++) {
       if (typeof config.instanceName === 'undefined' || cloudantServices[i].name === config.instanceName) {
         var credentials = cloudantServices[i].credentials;
-        if (credentials && credentials.url) {
-          outUrl = credentials.url;
+        if (credentials && credentials.host) {
+          outUrl = 'https://' + encodeURIComponent(credentials.host);
+          if (credentials.apikey) {
+            outCreds.iamApiKey = credentials.apikey;
+          }
           break;
         } else {
           throw new Error('Invalid Cloudant service in vcapServices');
@@ -123,7 +126,8 @@ module.exports = function(config) {
     outUrl = outUrl.slice(0, -1);
   }
 
-  return (outUrl || null);
+  outCreds.outUrl = (outUrl || null);
+  return outCreds;
 };
 
 module.exports.getOptions = getOptions;

--- a/test/legacy/reconfigure.js
+++ b/test/legacy/reconfigure.js
@@ -1,4 +1,4 @@
-// Copyright © 2015, 2017 IBM Corp. All rights reserved.
+// Copyright © 2015, 2018 IBM Corp. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -32,162 +32,200 @@ describe('Reconfigure', function() {
 
   it('allows only an account to be passed in', function(done) {
     var credentials = { account: 'myaccount'};
-    var url = reconfigure(credentials);
-    url.should.be.a.String;
-    url.should.equal('https://myaccount.cloudant.com');
+    var outCreds = reconfigure(credentials);
+    outCreds.outUrl.should.be.a.String;
+    outCreds.outUrl.should.equal('https://myaccount.cloudant.com');
     done();
   });
 
   it('allows an account and a password to be passed in', function(done) {
     var credentials = { account: 'myaccount', password: 'mypassword'};
-    var url = reconfigure(credentials);
-    url.should.be.a.String;
-    url.should.equal('https://myaccount:mypassword@myaccount.cloudant.com');
+    var outCreds = reconfigure(credentials);
+    outCreds.outUrl.should.be.a.String;
+    outCreds.outUrl.should.equal('https://myaccount:mypassword@myaccount.cloudant.com');
     done();
   });
 
   it('allows a key and an account and a password to be passed in', function(done) {
     var credentials = { account: 'myaccount', password: 'mypassword', key: 'mykey'};
-    var url = reconfigure(credentials);
-    url.should.be.a.String;
-    url.should.equal('https://mykey:mypassword@myaccount.cloudant.com');
+    var outCreds = reconfigure(credentials);
+    outCreds.outUrl.should.be.a.String;
+    outCreds.outUrl.should.equal('https://mykey:mypassword@myaccount.cloudant.com');
     done();
   });
 
   it('allows a username and an account and a password to be passed in', function(done) {
     var credentials = { account: 'myaccount', password: 'mypassword', username: 'myusername'};
-    var url = reconfigure(credentials);
-    url.should.be.a.String;
-    url.should.equal('https://myusername:mypassword@myaccount.cloudant.com');
+    var outCreds = reconfigure(credentials);
+    outCreds.outUrl.should.be.a.String;
+    outCreds.outUrl.should.equal('https://myusername:mypassword@myaccount.cloudant.com');
     done();
   });
 
   it('allows a key and an full domain and a password to be passed in', function(done) {
     var credentials = { account: 'myaccount.cloudant.com', password: 'mypassword', key: 'mykey'};
-    var url = reconfigure(credentials);
-    url.should.be.a.String;
-    url.should.equal('https://mykey:mypassword@myaccount.cloudant.com');
+    var outCreds = reconfigure(credentials);
+    outCreds.outUrl.should.be.a.String;
+    outCreds.outUrl.should.equal('https://mykey:mypassword@myaccount.cloudant.com');
     done();
   });
 
   it('allows complex passwords', function(done) {
     var credentials = { account: 'myaccount', password: 'mypassword[]{}!#&='};
-    var url = reconfigure(credentials);
-    url.should.be.a.String;
-    url.should.equal('https://myaccount:mypassword%5B%5D%7B%7D!%23%26%3D@myaccount.cloudant.com');
+    var outCreds = reconfigure(credentials);
+    outCreds.outUrl.should.be.a.String;
+    outCreds.outUrl.should.equal('https://myaccount:mypassword%5B%5D%7B%7D!%23%26%3D@myaccount.cloudant.com');
     done();
   });
 
   it('allows a local CouchDB url to used', function(done) {
     var credentials = { url: 'http://localhost:5984' };
-    var url = reconfigure(credentials);
-    url.should.be.a.String;
-    url.should.equal('http://localhost:5984');
+    var outCreds = reconfigure(credentials);
+    outCreds.outUrl.should.be.a.String;
+    outCreds.outUrl.should.equal('http://localhost:5984');
     done();
   });
 
   it('allows an HTTP Cloudant URL - switching to HTTPS', function(done) {
     var credentials = { url: 'http://mykey:mypassword@mydomain.cloudant.com' };
-    var url = reconfigure(credentials);
-    url.should.be.a.String;
-    url.should.equal('https://mykey:mypassword@mydomain.cloudant.com');
+    var outCreds = reconfigure(credentials);
+    outCreds.outUrl.should.be.a.String;
+    outCreds.outUrl.should.equal('https://mykey:mypassword@mydomain.cloudant.com');
     done();
   });
 
   it('allows an HTTP Cloudant URL with a port number - switching to HTTPS', function(done) {
     var credentials = { url: 'http://mykey:mypassword@mydomain.cloudant.com:80' };
-    var url = reconfigure(credentials);
-    url.should.be.a.String;
-    url.should.equal('https://mykey:mypassword@mydomain.cloudant.com');
+    var outCreds = reconfigure(credentials);
+    outCreds.outUrl.should.be.a.String;
+    outCreds.outUrl.should.equal('https://mykey:mypassword@mydomain.cloudant.com');
     done();
   });
 
   // Issue cloudant/nodejs-cloudant#129
   it('fixes a Cloudant URL with a trailing / - removing the /', function(done) {
     var credentials = { url: 'https://mykey:mypassword@mydomain.cloudant.com/' };
-    var url = reconfigure(credentials);
-    url.should.be.a.String;
-    url.should.equal('https://mykey:mypassword@mydomain.cloudant.com');
+    var outCreds = reconfigure(credentials);
+    outCreds.outUrl.should.be.a.String;
+    outCreds.outUrl.should.equal('https://mykey:mypassword@mydomain.cloudant.com');
     done();
   });
 
   // Issue cloudant/nodejs-cloudant#141
   it('Allows account names with dashes', function(done) {
     var credentials = { account: 'this-account-has-dashes.cloudant.com', password: 'bacon' };
-    var url = reconfigure(credentials);
-    url.should.be.a.String;
-    url.should.equal('https://this-account-has-dashes:bacon@this-account-has-dashes.cloudant.com');
+    var outCreds = reconfigure(credentials);
+    outCreds.outUrl.should.be.a.String;
+    outCreds.outUrl.should.equal('https://this-account-has-dashes:bacon@this-account-has-dashes.cloudant.com');
     done();
   });
 
-  it('gets first URL from vcap containing single service', function(done) {
+  it('gets first host from vcap containing single service', function(done) {
     var config = {vcapServices: {cloudantNoSQLDB: [
-      {credentials: {url: 'http://mykey:mypassword@mydomain.cloudant.com'}}
+      {credentials: {host: 'mydomain.cloudant.com'}}
     ]}};
-    var url = reconfigure(config);
-    url.should.be.a.String;
-    url.should.equal('http://mykey:mypassword@mydomain.cloudant.com');
+    var outCreds = reconfigure(config);
+    outCreds.outUrl.should.be.a.String;
+    outCreds.outUrl.should.equal('https://mydomain.cloudant.com');
     done();
   });
 
-  it('gets URL by instance name from vcap containing single service', function(done) {
+  it('gets host by instance name from vcap containing single service', function(done) {
     var config = {instanceName: 'serviceA',
       vcapServices: {cloudantNoSQLDB: [
-      {name: 'serviceA', credentials: {url: 'http://mykey:mypassword@mydomain.cloudant.com'}}
+      {name: 'serviceA', credentials: {host: 'mydomain.cloudant.com'}}
       ]}};
-    var url = reconfigure(config);
-    url.should.be.a.String;
-    url.should.equal('http://mykey:mypassword@mydomain.cloudant.com');
+    var outCreds = reconfigure(config);
+    outCreds.outUrl.should.be.a.String;
+    outCreds.outUrl.should.equal('https://mydomain.cloudant.com');
     done();
   });
 
-  it('gets URL by instance name alias from vcap containing single service', function(done) {
+  it('gets host by instance name alias from vcap containing single service', function(done) {
     var config = { vcapInstanceName: 'serviceA', // alias of 'instanceName'
       vcapServices: { cloudantNoSQLDB: [
-        { name: 'serviceA', credentials: { url: 'http://mykey:mypassword@mydomain.cloudant.com' } }
+        { name: 'serviceA', credentials: { host: 'mydomain.cloudant.com' } }
       ]}
     };
-    var url = reconfigure(config);
-    url.should.be.a.String;
-    url.should.equal('http://mykey:mypassword@mydomain.cloudant.com');
+    var outCreds = reconfigure(config);
+    outCreds.outUrl.should.be.a.String;
+    outCreds.outUrl.should.equal('https://mydomain.cloudant.com');
     done();
   });
 
-  it('gets URL by service name and instance name from vcap containing single service', function(done) {
+  it('gets host by service name and instance name from vcap containing single service', function(done) {
     var config = {
       vcapServiceName: 'myNoSQLDB', vcapInstanceName: 'instanceA',
       vcapServices: { myNoSQLDB: [
-        { name: 'instanceA', credentials: { url: 'http://mykey:mypassword@mydomain.cloudant.com' } }
+        { name: 'instanceA', credentials: { host: 'mydomain.cloudant.com' } }
       ]}
     };
-    var url = reconfigure(config);
-    url.should.be.a.String;
-    url.should.equal('http://mykey:mypassword@mydomain.cloudant.com');
+    var outCreds = reconfigure(config);
+    outCreds.outUrl.should.be.a.String;
+    outCreds.outUrl.should.equal('https://mydomain.cloudant.com');
     done();
   });
 
-  it('gets first URL from vcap containing multiple services', function(done) {
+  it('gets first host from vcap containing multiple services', function(done) {
     var config = {vcapServices: {cloudantNoSQLDB: [
-      {credentials: {url: 'http://mykey:mypassword@mydomain.cloudant.com'}},
-      {credentials: {url: 'http://foo.bar'}},
-      {credentials: {url: 'http://foo.bar'}}
+      {credentials: {host: 'mydomain.cloudant.com'}},
+      {credentials: {host: 'foo.bar'}},
+      {credentials: {host: 'foo.bar'}}
     ]}};
-    var url = reconfigure(config);
-    url.should.be.a.String;
-    url.should.equal('http://mykey:mypassword@mydomain.cloudant.com');
+    var outCreds = reconfigure(config);
+    outCreds.outUrl.should.be.a.String;
+    outCreds.outUrl.should.equal('https://mydomain.cloudant.com');
     done();
   });
 
-  it('gets URL by instance name from vcap containing multiple services', function(done) {
+  it('gets host by instance name from vcap containing multiple services', function(done) {
     var config = {instanceName: 'serviceC',
       vcapServices: {cloudantNoSQLDB: [
-      {name: 'serviceA', credentials: {url: 'http://foo.bar'}},
-      {name: 'serviceB', credentials: {url: 'http://foo.bar'}},
-      {name: 'serviceC', credentials: {url: 'http://mykey:mypassword@mydomain.cloudant.com'}}
+      {name: 'serviceA', credentials: {host: 'foo.bar'}},
+      {name: 'serviceB', credentials: {host: 'foo.bar'}},
+      {name: 'serviceC', credentials: {host: 'mydomain.cloudant.com'}}
       ]}};
-    var url = reconfigure(config);
-    url.should.be.a.String;
-    url.should.equal('http://mykey:mypassword@mydomain.cloudant.com');
+    var outCreds = reconfigure(config);
+    outCreds.outUrl.should.be.a.String;
+    outCreds.outUrl.should.equal('https://mydomain.cloudant.com');
+    done();
+  });
+
+  it('gets first IAM key from vcap containing single service', function(done) {
+    var config = {vcapServices: {cloudantNoSQLDB: [
+      {credentials: {apikey: '1234api', host: 'user-bluemix.cloudant.com'}}
+    ]}};
+    var outCreds = reconfigure(config);
+    outCreds.iamApiKey.should.be.a.String;
+    outCreds.iamApiKey.should.equal('1234api');
+    outCreds.outUrl.should.equal('https://user-bluemix.cloudant.com');
+    done();
+  });
+
+  it('gets first host from vcap containing multiple services', function(done) {
+    var config = {vcapServices: {cloudantNoSQLDB: [
+      {credentials: {apikey: 'a1234api', host: 'a-user-bluemix.cloudant.com'}},
+      {credentials: {host: 'foo.bar'}},
+      {credentials: {host: 'foo.bar'}}
+    ]}};
+    var outCreds = reconfigure(config);
+    outCreds.iamApiKey.should.be.a.String;
+    outCreds.iamApiKey.should.equal('a1234api');
+    outCreds.outUrl.should.equal('https://a-user-bluemix.cloudant.com');
+    done();
+  });
+
+  it('gets IAM key by instance name from vcap containing multiple services', function(done) {
+    var config = {instanceName: 'serviceB',
+      vcapServices: {cloudantNoSQLDB: [
+      {name: 'serviceA', credentials: {apikey: 'a1234api', host: 'a-user-bluemix.cloudant.com'}},
+      {name: 'serviceB', credentials: {apikey: 'b1234api', host: 'b-user-bluemix.cloudant.com'}},
+      {name: 'serviceC', credentials: {host: 'mydomain.cloudant.com'}}
+      ]}};
+    var outCreds = reconfigure(config);
+    outCreds.iamApiKey.should.be.a.String;
+    outCreds.iamApiKey.should.equal('b1234api');
+    outCreds.outUrl.should.equal('https://b-user-bluemix.cloudant.com');
     done();
   });
 
@@ -206,8 +244,8 @@ describe('Reconfigure', function() {
   it('errors for missing service in vcap', function(done) {
     var config = {instanceName: 'serviceC',
       vcapServices: {cloudantNoSQLDB: [
-      {name: 'serviceA', credentials: {url: 'http://foo.bar'}},
-      {name: 'serviceB', credentials: {url: 'http://foo.bar'}} // missing "serviceC"
+      {name: 'serviceA', credentials: {host: 'foo.bar'}},
+      {name: 'serviceB', credentials: {host: 'foo.bar'}} // missing "serviceC"
       ]}};
     should(function() { reconfigure(config); }).throw('Missing Cloudant service in vcapServices');
     done();
@@ -221,30 +259,35 @@ describe('Reconfigure', function() {
     done();
   });
 
-  it('errors for invalid service in vcap - missing url', function(done) {
+  it('errors for invalid service in legacy vcap - missing host', function(done) {
     var config = {vcapServices: {cloudantNoSQLDB: [
-      {name: 'serviceA', credentials: {}} // invalid service, missing url
+      {name: 'serviceA', credentials: {}} // invalid service, missing host
     ]}};
     should(function() { reconfigure(config); }).throw('Invalid Cloudant service in vcapServices');
     done();
   });
 
-  it('detects bad urls', function(done) {
-    var credentials = { url: 'invalid' };
-    var url = reconfigure(credentials);
-    assert.equal(url, null);
-    var credentials = { url: '' };
-    var url = reconfigure(credentials);
-    assert.equal(url, null);
-    var credentials = { url: 'http://' };
-    var url = reconfigure(credentials);
-    assert.equal(url, null);
+  it('errors for invalid service in vcap - missing host', function(done) {
+    var config = {vcapServices: {cloudantNoSQLDB: [
+      {name: 'serviceA', credentials: {apikey: 'a1234api'}} // invalid service, missing host
+    ]}};
+    should(function() { reconfigure(config); }).throw('Invalid Cloudant service in vcapServices');
+    done();
+  });
+
+  it('detects bad hosts', function(done) {
+    var credentials = { host: 'invalid' };
+    var outCreds = reconfigure(credentials);
+    assert.equal(outCreds.outUrl, null);
+    var credentials = { host: '' };
+    var outCreds = reconfigure(credentials);
+    assert.equal(outCreds.outUrl, null);
     var credentials = { };
-    var url = reconfigure(credentials);
-    assert.equal(url, null);
+    var outCreds = reconfigure(credentials);
+    assert.equal(outCreds.outUrl, null);
     var credentials = 'invalid';
-    var url = reconfigure(credentials);
-    assert.equal(url, null);
+    var outCreds = reconfigure(credentials);
+    assert.equal(outCreds.outUrl, null);
 
     done();
   });


### PR DESCRIPTION
Thanks for your hard work, please ensure all items are complete before opening.

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://github.com/cloudant/nodejs-cloudant/blob/master/DCO1.1.txt)
- [x] You have added tests for any code changes
- [x] You have updated the [CHANGES.md](https://github.com/cloudant/nodejs-cloudant/blob/master/CHANGES.md)
- [x] You have completed the PR template below:

## What

Added support for IAM API key when creating a Cloudant client using `vcapServices`:
```javascript
var VCAP_SERVICES = '{"cloudantNoSQLDB": [{"credentials": {"apikey": "api123key", "username": "bluemix-user"}}]}'
var cloudant = Cloudant({ vcapServices: JSON.parse(VCAP_SERVICES) });
```

## How

- Updated `reconfigure.js` to return a dictionary object with either a) url with legacy creds or b) IAM with url
- If IAM key exists in vcap services, add `IAMPlugin` to client
- Added tests to assert vcap services IAM key in `reconfigure.js`

## Testing

Added tests in `reconfigure` for asserting IAM key and URL when creating client with single and multiple vcap services.
