### PR TITLE
Removed addition of statusCode to response objects

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,5 @@
 # UNRELEASED
+- [FIXED] Removed addition of `statusCode` to response objects returned by promises.
 - [IMPROVED] Added support for IAM API key when initializing client with VCAP_SERVICES environment variable.
 
 # 2.2.0 (2018-04-30)

--- a/lib/client.js
+++ b/lib/client.js
@@ -205,7 +205,6 @@ class CloudantClient {
           if (data) {
             try {
               data = JSON.parse(data);
-              data.statusCode = response.statusCode;
             } catch (err) {}
           } else {
             data = { statusCode: response.statusCode };

--- a/test/client.js
+++ b/test/client.js
@@ -1327,20 +1327,21 @@ describe('CloudantClient', function() {
     describe('with no other plugins', function() {
       it('performs request and returns response with promise client', function(done) {
         var mocks = nock(SERVER)
-            .get(DBNAME)
-            .reply(200, {doc_count: 1});
+            .get(`${DBNAME}/${DOCID}`)
+            .reply(200, { _id: DOCID, _rev: '1-xxxxxx', foo: 'bar' });
 
         var cloudantClient = new Client({ plugins: 'promises' });
         assert.equal(cloudantClient._plugins.length, 0);
         assert.ok(cloudantClient._cfg.usePromises);
 
         var options = {
-          url: SERVER + DBNAME,
+          url: SERVER + DBNAME + '/' + DOCID,
           auth: { username: ME, password: PASSWORD },
           method: 'GET'
         };
         var p = cloudantClient.request(options).then(function(data) {
-          assert.equal(data.doc_count, 1);
+          assert.equal(Object.keys(data).length, 3);
+          assert.equal(data.foo, 'bar');
           mocks.done();
           done();
         }).catch(function(err) {


### PR DESCRIPTION
Thanks for your hard work, please ensure all items are complete before opening.

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://github.com/cloudant/nodejs-cloudant/blob/master/DCO1.1.txt)
- [x] You have added tests for any code changes
- [x] You have updated the [CHANGES.md](https://github.com/cloudant/nodejs-cloudant/blob/master/CHANGES.md)
- [x] You have completed the PR template below:

## What
Removed addition of `statusCode` to response objects.

## Testing
Update existing unit test to assert object key length.

## Issues
Fixes #308.