### PR TITLE
Handle cases when username, password, and url exist during client creation

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,5 @@
 # UNRELEASED
+- [FIXED] Case where `username` and `password` options were not used if a `url` was supplied.
 
 # 2.3.0 (2018-06-08)
 - [FIXED] Removed addition of `statusCode` to response objects returned by promises.

--- a/README.md
+++ b/README.md
@@ -148,6 +148,12 @@ var Cloudant = require('@cloudant/cloudant')
 var cloudant = Cloudant("http://MYUSERNAME:MYPASSWORD@localhost:5984");
 ~~~
 
+**Note**: If you pass in a `username`, `password`, and `url` that contains credentials, the `username` and `password` will supercede the credentials within the `url`.  For example, `myusername` and `mypassword` will be used in the code below during authentication:
+~~~ js
+var Cloudant = require('@cloudant/cloudant')
+var cloudant = Cloudant({username:'myusername', password:'mypassword', url:'http://user:pass@localhost:5984'});
+~~~
+
 #### 2. Using account credentials:
 
 ##### 2.1. Connecting to Cloudant

--- a/lib/reconfigure.js
+++ b/lib/reconfigure.js
@@ -29,6 +29,9 @@ module.exports = function(config) {
   config = JSON.parse(JSON.stringify(config)); // clone
   var outUrl;
   var outCreds = {};
+  var options;
+  var username;
+  var password;
   // if a full URL is passed in
   if (config.url) {
     // parse the URL
@@ -58,6 +61,14 @@ module.exports = function(config) {
 
       // reconstruct the URL
       config.url = url.format(parsed);
+    } else {
+      options = getOptions(config);
+      username = options.username;
+      password = options.password;
+      if (username && password) {
+        config.url = parsed.protocol + '//' + encodeURIComponent(username) + ':' +
+                    encodeURIComponent(password) + '@' + parsed.host;
+      }
     }
     outUrl = config.url;
   } else if (config.vcapServices) {
@@ -100,10 +111,9 @@ module.exports = function(config) {
                 config.account.match &&
                 config.account.match(/([^.]+)\.cloudant\.com/);
     if (match) { config.account = match[1]; }
-
-    var options = getOptions(config);
-    var username = options.username;
-    var password = options.password;
+    options = getOptions(config);
+    username = options.username;
+    password = options.password;
 
     // Configure for Cloudant, either authenticated or anonymous.
     if (config.account && password) {

--- a/test/legacy/reconfigure.js
+++ b/test/legacy/reconfigure.js
@@ -62,6 +62,23 @@ describe('Reconfigure', function() {
     done();
   });
 
+  // Issue cloudant/nodejs-cloudant#323
+  it('allows a username, a password, and url to be passed in', function(done) {
+    var credentials = { username: 'myusername', password: 'mypassword', url: 'http://localhost:8081' };
+    var outCreds = reconfigure(credentials);
+    outCreds.outUrl.should.be.a.String;
+    outCreds.outUrl.should.equal('http://myusername:mypassword@localhost:8081');
+    done();
+  });
+
+  it('allows a username and password to supersede credentials supplied in a url', function(done) {
+    var credentials = { username: 'myusername', password: 'mypassword', url: 'http://user:pass@localhost:8081' };
+    var outCreds = reconfigure(credentials);
+    outCreds.outUrl.should.be.a.String;
+    outCreds.outUrl.should.equal('http://myusername:mypassword@localhost:8081');
+    done();
+  });
+
   it('allows a key and an full domain and a password to be passed in', function(done) {
     var credentials = { account: 'myaccount.cloudant.com', password: 'mypassword', key: 'mykey'};
     var outCreds = reconfigure(credentials);


### PR DESCRIPTION
Thanks for your hard work, please ensure all items are complete before opening.

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://github.com/cloudant/nodejs-cloudant/blob/master/DCO1.1.txt)
- [x] You have added tests for any code changes
- [x] You have updated the [CHANGES.md](https://github.com/cloudant/nodejs-cloudant/blob/master/CHANGES.md)
- [x] You have completed the PR template below:

## What

Properly handle cases when `username`, `password`, and `url` exist during client creation.  This issue was discovered when creating a client against Cloudant Local.

## How

- If `username`, `password`, and `url` exist during client creation, add `username` and `password` to `url`

## Testing
New test to assert that username and password are added to url in `reconfigure.js`.

## Issues

fixes #323 