### PR TITLE
IAM plugin example shouldn't include creds in URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -361,7 +361,7 @@ var cloudant = new Cloudant({ url: myurl, maxAttempt: 5, plugins: [ 'iamauth', {
 
    For example:
    ```js
-   var cloudant = new Cloudant({ url: 'https://user:pass@examples.cloudant.com', plugins: { iamauth: { iamApiKey: 'xxxxxxxxxx' } } });
+   var cloudant = new Cloudant({ url: 'https://examples.cloudant.com', plugins: { iamauth: { iamApiKey: 'xxxxxxxxxx' } } });
    var mydb = cloudant.db.use('mydb');
    mydb.get('mydoc', function(err, data) {
      console.log(`Document contents: ${data.toString('utf8')}`);


### PR DESCRIPTION
The example for IAM authentication included legacy credentials in the URL. It shouldn't have.

Thanks for your hard work, please ensure all items are complete before opening.

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://github.com/cloudant/nodejs-cloudant/blob/master/DCO1.1.txt)
- [x] You have added tests for any code changes
- [x] You have updated the [CHANGES.md](https://github.com/cloudant/nodejs-cloudant/blob/master/CHANGES.md)
- [x] You have completed the PR template below:

## What

IAM plugin example shouldn't include creds in URL

## How

The example for IAM authentication included legacy credentials in the URL. It shouldn't have. They are removed.

## Testing

None.

## Issues

None.
