### PR TITLE
allow basic-auth url in vcap_services - fixes issue #327

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,6 @@
 # UNRELEASED
 - [FIXED] Case where `username` and `password` options were not used if a `url` was supplied.
+- [FIXED] Case where vcapServices was supplied with a basic-auth url
 
 # 2.3.0 (2018-06-08)
 - [FIXED] Removed addition of `statusCode` to response objects returned by promises.

--- a/lib/reconfigure.js
+++ b/lib/reconfigure.js
@@ -94,6 +94,8 @@ module.exports = function(config) {
           outUrl = 'https://' + encodeURIComponent(credentials.host);
           if (credentials.apikey) {
             outCreds.iamApiKey = credentials.apikey;
+          } else if (credentials.url) {
+            outUrl = credentials.url;
           }
           break;
         } else {

--- a/test/legacy/reconfigure.js
+++ b/test/legacy/reconfigure.js
@@ -246,6 +246,15 @@ describe('Reconfigure', function() {
     done();
   });
 
+  // Issue cloudant/nodejs-cloudant#327
+  it('allows a vcap_services basic-auth url', function(done) {
+    var credentials = { vcapServices: {"cloudantNoSQLDB":[{"credentials":{"username":"x","password":"y","host":"z.cloudant.com","port":443,"url":"https://x:y@z.cloudant.com"},"syslog_drain_url":null,"volume_mounts":[],"label":"cloudantNoSQLDB","provider":null,"plan":"Shared","name":"iot-cloudantNoSQLDB","tags":["data_management","ibm_created","lite","ibm_dedicated_public"]}]} };
+    var outCreds = reconfigure(credentials);
+    outCreds.outUrl.should.be.a.String;
+    outCreds.outUrl.should.equal('https://x:y@z.cloudant.com');
+    done();
+  });
+
   it('errors for empty vcap', function(done) {
     var config = {vcapServices: {}};
     should(function() { reconfigure(config); }).throw('Missing Cloudant service in vcapServices');


### PR DESCRIPTION
## Checklist

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)
- [x] Added tests for code changes _or_ test/build only changes
- [x] Updated the change log file (`CHANGES.md`|`CHANGELOG.md`) _or_ test/build only changes
- [x] Completed the PR template below:

## Description

Fixed a bug in reconfigure where `vcapServices` is supplied with a basic-auth URL. 

Fixes issue #327 

## Approach

Only the `hostname` was used and the `username`/`password` was ignored. I elected to pick the `url` parameter which contains the basic-auth credentials in the absence of an `apikey` in the `credentials` object.

## Schema & API Changes

- "No change"

## Security and Privacy

- "No change"

## Testing

 Added new tests:

- allows a vcap_services basic-auth url

## Monitoring and Logging

- "No change"
