### PR TITLE
Refactored remaining tests without unique DB names

### DIFF
--- a/test/legacy/api.js
+++ b/test/legacy/api.js
@@ -611,7 +611,7 @@ describe('Cloudant Query', function() {
 
   before(function(done) {
     const unique = uuid();
-    dbName = 'couchbackup_test_' + unique;
+    dbName = 'nodejs_cloudant_test_' + unique;
     var mocks = nock(SERVER)
       .put('/' + dbName).reply(200, { 'ok': true });
 
@@ -942,7 +942,7 @@ if (!process.env.NOCK_OFF) {
 }
 function test_gzip() {
   it('checks that the zipped response is unzipped', function(done) {
-    var dbName = 'mydb';
+    var dbName = `nodejs_cloudant_test_${uuid()}`;
     var mocks = nock(SERVER)
       .get('/' + dbName + '/x/y.css').replyWithFile(200, __dirname + '/y.css.gz', {
         'content-encoding': 'gzip',


### PR DESCRIPTION
## Checklist

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)
- [x] Added tests for code changes _or_ test/build only changes
- [x] Updated the change log file (`CHANGES.md`|`CHANGELOG.md`) _or_ test/build only changes
- [x] Completed the PR template below:

## Description

Fixed remaining tests that didn't use a unique db name.

### 1. Steps to reproduce and the simplest code sample possible to demonstrate the issue

Run tests in parallel.

### 2. What you expected to happen

Tests to pass.

### 3. What actually happened

Test failures e.g.
```
QA / Node8x / test.Cloudant Search."before all" hook
Error Message
The database could not be created, the file already exists.
```

## Approach

#334 re-enabled parallel testing, but no failures happened on the branch before it merged. Once it was merged the master build failed.

Some tests used non-unique DB names, replace these remaining test instances with unique db names.

## Schema & API Changes

- "No change"

## Security and Privacy

- "No change"

## Testing

- Modified existing tests because to correct static db names.

## Monitoring and Logging

- "No change"
