### PR TITLE
Prepare for version 2.4.0 release

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,6 @@
-# UNRELEASED
+# 2.4.0 (2018-09-19)
 - [FIXED] Case where `username` and `password` options were not used if a `url` was supplied.
-- [FIXED] Case where vcapServices was supplied with a basic-auth url
+- [FIXED] Case where `vcapServices` was supplied with a basic-auth `url`.
 
 # 2.3.0 (2018-06-08)
 - [FIXED] Removed addition of `statusCode` to response objects returned by promises.

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "type": "git",
     "url": "git@github.com:cloudant/nodejs-cloudant.git"
   },
-  "version": "2.4.0-SNAPSHOT",
+  "version": "2.4.0",
   "author": {
     "name": "IBM Cloudant",
     "email": "support@cloudant.com"


### PR DESCRIPTION
# 2.4.0 (2018-09-19)
- [FIXED] Case where `username` and `password` options were not used if a `url` was supplied.
- [FIXED] Case where vcapServices was supplied with a basic-auth url