### PR TITLE
feat: update the search params to latest

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -87,13 +87,46 @@ declare namespace cloudant {
         name: string;
     }
 
+    // https://console.bluemix.net/docs/services/Cloudant/api/search.html#queries
     interface SearchParams {
-        q: string;
-        include_docs?: boolean;
+        // A bookmark that was received from a previous search. Used for pagination.
         bookmark?: string;
+        // An array of field names for which facet counts are requested.
+        counts?: string[];
+        // Filters the result set using key value pairs supplied to the drilldown parameter.
+        drilldown?: string[];
+        // The name of a string field to group results by.
+        group_field?: string;
+        // The maximum group count when used in conjunction with group_field.
+        group_limit?: number;
+        // Defines the order of the groups in a search when used with group_field.
+        group_sort?: string | string[];
+        // Which fields are to be highlighted.
+        highlight_fields?: string[];
+        // String used before a highlighted word. Defaults to <em>.
+        highlight_pre_tag?: string;
+        // String used after a highlighted word. Defaults to </em>.
+        highlight_post_tag?: string;
+        // The number of gradments that are returned in highlights. Defaults to 1.
+        highlight_number?: number;
+        // The number of characters in each fragment for highlight. Defaults to 100.
+        highlight_size?: number;
+        // Include the full document bodies in the response. Defaults to false
+        include_docs?: boolean;
+        // An array of fields to include in the search results.
+        include_fields?: string[];
+        // The maximum number of returned documents. Positive integer up to 200.
         limit?: number;
-        skip?: number;
-        stale?: string;
+        // Alias of 'query'. One of q or query must be present.
+        q?: string;
+        // The Lucene query to perform. One of q or query must be present.
+        query?: string;
+        // Defines ranges for faceted numeric search fields.
+        ranges?: object;
+        // Specifies the sort order of the results.
+        sort?: string | string[];
+        // Do not wait for the index to finish building to return results.
+        stale?: boolean;
     }
 
     interface Security {


### PR DESCRIPTION
<!--
Thanks for your hard work, please ensure all items are complete before opening.
-->
## Checklist

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)
- [ ] Added tests for code changes _or_ test/build only changes
- [ ] Updated the change log file (`CHANGES.md`|`CHANGELOG.md`) _or_ test/build only changes
- [ ] Completed the PR template below:

## Description
<!--
Provide a short description; saving the detail for the `Approach` section

Also EITHER:
Link to issue this PR is resolving, use the Fixes #nnn form so that the
issue closes automatically when the PR merges e.g.:

Fixes #23

OR

For PRs without an associated issue and/or test/build issues

### 1. Steps to reproduce and the simplest code sample possible to demonstrate the issue
### 2. What you expected to happen
### 3. What actually happened
-->
I was trying to perform the highlighting feature provided by cloudant and nano and noticed that they were missing in this interface and thus could not be used.

## Approach

<!--
Be brief: which component(s) of the code base does the fix focus on.

A place to note whether the part of the code base that is being worked is
particularly sensitive.
-->
nano has already made these changes https://github.com/apache/couchdb-nano/blob/master/lib/nano.d.ts#L1012-L1068

## Schema & API Changes

<!--
EITHER:

- "No change"

OR

For public API (as opposed to internal) changes

- "Fixing bug in API, will change x in such-and-such way"
-->
Fixing missing parameters in API

## Security and Privacy

<!--
EITHER:

- "No change"

OR

"Making changes in e.g. auth|https|encryption|io
need to be careful about..."

-->
- "No change"

## Testing

<!--
EITHER:

- Added new tests:
    - test x
    - test y
    - test z

OR

- Modified existing tests because ...

OR

- N/A build or packaging only changes

OR

In exceptional circumstances there may be a good reason we can't add automated
tests, for example if a specific device is required to reproduce a problem.

- No new tests because...
-->

## Monitoring and Logging
<!--
EITHER:

- "No change"

OR

- "Added new log line X..."
-->
- "No change"
