### PR TITLE
Fix plugin configuration when instantiating a new client using VCAP

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,6 @@
+# UNRELEASED
+- [FIXED] Don't override `plugins` array when instantiating a new client using VCAP.
+
 # 2.4.0 (2018-09-19)
 - [FIXED] Case where `username` and `password` options were not used if a `url` was supplied.
 - [FIXED] Case where `vcapServices` was supplied with a basic-auth `url`.

--- a/lib/client.js
+++ b/lib/client.js
@@ -45,14 +45,19 @@ class CloudantClient {
     self._usePromises = false;
     self.useLegacyPlugin = false;
 
-    // build plugin array
+    // Build plugin array.
     var plugins = [];
-    // If IAM key found in VCAP, add IAM plugin
+
     if (self._cfg.creds && self._cfg.creds.iamApiKey) {
-      plugins.push({ iamauth: { iamApiKey: self._cfg.creds.iamApiKey } });
-    } else if (typeof this._cfg.plugin === 'undefined' && typeof this._cfg.plugins === 'undefined') {
-      plugins = [ 'cookieauth' ]; // default
-    } else {
+      // => Found IAM API key in VCAP - Add 'iamauth' plugin.
+      plugins = [ { iamauth: { iamApiKey: self._cfg.creds.iamApiKey } } ];
+    } else if (typeof this._cfg.plugins === 'undefined') {
+      // => No plugins specified - Add 'cookieauth' plugin.
+      plugins = [ 'cookieauth' ];
+    }
+
+    // Add user specified plugins.
+    if (typeof this._cfg.plugins !== 'undefined') {
       [].concat(self._cfg.plugins).forEach(function(plugin) {
         if (typeof plugin !== 'function' || plugin.pluginVersion >= 2) {
           plugins.push(plugin);


### PR DESCRIPTION
<!--
Thanks for your hard work, please ensure all items are complete before opening.
-->
## Checklist

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)
- [x] Added tests for code changes _or_ test/build only changes
- [x] Updated the change log file (`CHANGES.md`|`CHANGELOG.md`) _or_ test/build only changes
- [x] Completed the PR template below:

## Description

<!--
Provide a short description; saving the detail for the `Approach` section

Also EITHER:
Link to issue this PR is resolving, use the Fixes #nnn form so that the
issue closes automatically when the PR merges e.g.:

Fixes #23

OR

For PRs without an associated issue and/or test/build issues

### 1. Steps to reproduce and the simplest code sample possible to demonstrate the issue
### 2. What you expected to happen
### 3. What actually happened
-->
Fix plugin configuration when instantiating a new client using VCAP.

Fixes #340.

## Approach

<!--
Be brief: which component(s) of the code base does the fix focus on.

A place to note whether the part of the code base that is being worked is
particularly sensitive.
-->
Always look at the `plugins` array for user specified plugins.

## Schema & API Changes
No change.
<!--
EITHER:

- "No change"

OR

For public API (as opposed to internal) changes

- "Fixing bug in API, will change x in such-and-such way"
-->

## Security and Privacy
No change.
<!--
EITHER:

- "No change"

OR

"Making changes in e.g. auth|https|encryption|io
need to be careful about..."

-->

## Testing
Added additional unit test.
<!--
EITHER:

- Added new tests:
    - test x
    - test y
    - test z

OR

- Modified existing tests because ...

OR

- N/A build or packaging only changes

OR

In exceptional circumstances there may be a good reason we can't add automated
tests, for example if a specific device is required to reproduce a problem.

- No new tests because...
-->

## Monitoring and Logging
No change.
<!--
EITHER:

- "No change"

OR

- "Added new log line X..."
-->
