### PR TITLE
Prepare version 2.5.0 release

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,4 @@
-# UNRELEASED
+# 2.5.0 (2018-11-07)
 - [FIXED] Don't override `plugins` array when instantiating a new client using VCAP.
 
 # 2.4.0 (2018-09-19)

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "type": "git",
     "url": "git@github.com:cloudant/nodejs-cloudant.git"
   },
-  "version": "2.5.0-SNAPSHOT",
+  "version": "2.5.0",
   "author": {
     "name": "IBM Cloudant",
     "email": "support@cloudant.com"


### PR DESCRIPTION
# 2.5.0 (2018-11-07)
- [FIXED] Don't override `plugins` array when instantiating a new client using VCAP.