### PR TITLE
Prepare version 3.0.0 release

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,10 @@
-# 3.0.0 UNRELEASED
+# 3.0.0 (2018-11-20)
 - [FIXED] Expose `BasePlugin` type in Cloudant client.
 - [FIXED] Set `parseUrl = false` on underlying Nano instance.
+- [BREAKING CHANGE] Due to the Nano 7.x upgrade all return types are now a
+  `Promise` (except for the `...AsStream` functions). _See
+  [api-migration.md](https://github.com/cloudant/nodejs-cloudant/blob/master/api-migration.md#2x--3x)
+  for migration details._
 - [REMOVED] Remove nodejs-cloudant TypeScript type definitions for
   `db.search`. These definitions are now imported directly from Nano.
 - [REMOVED] Removed support for the deprecated Cloudant virtual hosts feature.

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "type": "git",
     "url": "git@github.com:cloudant/nodejs-cloudant.git"
   },
-  "version": "3.0.0-SNAPSHOT",
+  "version": "3.0.0",
   "author": {
     "name": "IBM Cloudant",
     "email": "support@cloudant.com"


### PR DESCRIPTION
# 3.0.0 (2018-11-20)
- [FIXED] Expose `BasePlugin` type in Cloudant client.
- [FIXED] Set `parseUrl = false` on underlying Nano instance.
- [BREAKING CHANGE] Due to the Nano 7.x upgrade all return types are now a
  `Promise` (except for the `...AsStream` functions). _See
  [api-migration.md](https://github.com/cloudant/nodejs-cloudant/blob/master/api-migration.md#2x--3x)
  for migration details._
- [REMOVED] Remove nodejs-cloudant TypeScript type definitions for
  `db.search`. These definitions are now imported directly from Nano.
- [REMOVED] Removed support for the deprecated Cloudant virtual hosts feature.
- [UPGRADED] Using nano==7.1.1 dependency.