### PR TITLE
Set `parseURL = false` on underlying Nano instance.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,6 @@
 # 3.0.0 UNRELEASED
 - [FIXED] Expose `BasePlugin` type in Cloudant client.
+- [FIXED] Set `parseUrl = false` on underlying Nano instance.
 - [REMOVED] Remove nodejs-cloudant TypeScript type definitions for
   `db.search`. These definitions are now imported directly from Nano.
 - [REMOVED] Removed support for the deprecated Cloudant virtual hosts feature.

--- a/cloudant.js
+++ b/cloudant.js
@@ -55,7 +55,12 @@ function Cloudant(options, callback) {
     return cloudantClient.request(req, callback);
   };
 
-  var nanoOptions = { url: creds.outUrl, request: cloudantRequest, log: nanodebug };
+  var nanoOptions = {
+    log: nanodebug,
+    parseUrl: false, // always return server object
+    request: cloudantRequest,
+    url: creds.outUrl
+  };
   if (options.cookie) {
     nanoOptions.cookie = options.cookie; // legacy - sets 'X-CouchDB-WWW-Authenticate' header
   }


### PR DESCRIPTION
<!--
Thanks for your hard work, please ensure all items are complete before opening.
-->
## Checklist

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)
- [ ] Added tests for code changes _or_ test/build only changes
- [x] Updated the change log file (`CHANGES.md`|`CHANGELOG.md`) _or_ test/build only changes
- [x] Completed the PR template below:

## Description
Ensure that Nano always returns a server object.
<!--
Provide a short description; saving the detail for the `Approach` section

Also EITHER:
Link to issue this PR is resolving, use the Fixes #nnn form so that the
issue closes automatically when the PR merges e.g.:

Fixes #23

OR

For PRs without an associated issue and/or test/build issues

### 1. Steps to reproduce and the simplest code sample possible to demonstrate the issue
### 2. What you expected to happen
### 3. What actually happened
-->

## Approach
Add `parseUrl: false` option when instantiating Nano client.
<!--
Be brief: which component(s) of the code base does the fix focus on.

A place to note whether the part of the code base that is being worked is
particularly sensitive.
-->

## Schema & API Changes
No change.
<!--
EITHER:

- "No change"

OR

For public API (as opposed to internal) changes

- "Fixing bug in API, will change x in such-and-such way"
-->

## Security and Privacy
No change.
<!--
EITHER:

- "No change"

OR

"Making changes in e.g. auth|https|encryption|io
need to be careful about..."

-->

## Testing
Covered in existing test suite.
<!--
EITHER:

- Added new tests:
    - test x
    - test y
    - test z

OR

- Modified existing tests because ...

OR

- N/A build or packaging only changes

OR

In exceptional circumstances there may be a good reason we can't add automated
tests, for example if a specific device is required to reproduce a problem.

- No new tests because...
-->

## Monitoring and Logging
No change.
<!--
EITHER:

- "No change"

OR

- "Added new log line X..."
-->
