### PR TITLE
Use named import for `request.CoreOptions` type

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -6,4 +6,5 @@ jsdoc/
 node_modules/
 templates/
 test/legacy/
+test/typescript/
 tmp/

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,6 @@
+# UNRELEASED
+- [FIXED] Use named import for `request.CoreOptions` type.
+
 # 3.0.0 (2018-11-20)
 - [FIXED] Expose `BasePlugin` type in Cloudant client.
 - [FIXED] Set `parseUrl = false` on underlying Nano instance.

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "uuid": "^3.0.1"
   },
   "scripts": {
-    "test": "eslint --ignore-path .eslintignore . && mocha && npm run tslint && npm audit",
+    "test": "eslint --ignore-path .eslintignore . && tsc test/typescript/*.ts && mocha && npm run tslint && npm audit",
     "test-verbose": "env DEBUG='*,-mocha:*' npm run test",
     "test-live": "NOCK_OFF=true mocha",
     "test-live-verbose": "env DEBUG='*,-mocha:*' npm run test-live",

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,2 +1,3 @@
+--exclude test/typescript/*.js
 --recursive
 --timeout 10000

--- a/test/typescript/cloudant.ts
+++ b/test/typescript/cloudant.ts
@@ -1,0 +1,17 @@
+// Copyright © 2018 IBM Corp. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Ensure Cloudant type declaration files can be imported without error.
+
+export import cloudant = require('../../types/index');

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import * as nano from 'nano';
-import CoreOptions from "request";
+import { CoreOptions } from 'request';
 
 declare function cloudant(
     config: cloudant.Configuration | string,


### PR DESCRIPTION
<!--
Thanks for your hard work, please ensure all items are complete before opening.
-->
## Checklist

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)
- [x] Added tests for code changes _or_ test/build only changes
- [x] Updated the change log file (`CHANGES.md`|`CHANGELOG.md`) _or_ test/build only changes
- [x] Completed the PR template below:

## Description
Use named import for `request.CoreOptions` type.

Fixes #350.
<!--
Provide a short description; saving the detail for the `Approach` section

Also EITHER:
Link to issue this PR is resolving, use the Fixes #nnn form so that the
issue closes automatically when the PR merges e.g.:

Fixes #23

OR

For PRs without an associated issue and/or test/build issues

### 1. Steps to reproduce and the simplest code sample possible to demonstrate the issue
### 2. What you expected to happen
### 3. What actually happened
-->

<!--
Be brief: which component(s) of the code base does the fix focus on.

A place to note whether the part of the code base that is being worked is
particularly sensitive.
-->

## Schema & API Changes
No change.
<!--
EITHER:

- "No change"

OR

For public API (as opposed to internal) changes

- "Fixing bug in API, will change x in such-and-such way"
-->

## Security and Privacy
No change.
<!--
EITHER:

- "No change"

OR

"Making changes in e.g. auth|https|encryption|io
need to be careful about..."

-->

## Testing

Added new test for importing the typescript types `test/typescript/cloudant.ts`.

<!--
EITHER:

- Added new tests:
    - test x
    - test y
    - test z

OR

- Modified existing tests because ...

OR

- N/A build or packaging only changes

OR

In exceptional circumstances there may be a good reason we can't add automated
tests, for example if a specific device is required to reproduce a problem.

- No new tests because...
-->

## Monitoring and Logging
No change.
<!--
EITHER:

- "No change"

OR

- "Added new log line X..."
-->
