### PR TITLE
Prepare version 3.0.1 release

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,4 @@
-# UNRELEASED
+# 3.0.1 (2018-11-22)
 - [FIXED] Use named import for `request.CoreOptions` type.
 
 # 3.0.0 (2018-11-20)

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "type": "git",
     "url": "git@github.com:cloudant/nodejs-cloudant.git"
   },
-  "version": "3.0.1-SNAPSHOT",
+  "version": "3.0.1",
   "author": {
     "name": "IBM Cloudant",
     "email": "support@cloudant.com"


### PR DESCRIPTION
# 3.0.1 (2018-11-22)
- [FIXED] Use named import for `request.CoreOptions` type.