### PR TITLE
Prepare version 3.0.2 release

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,4 @@
-# UNRELEASED
+# 3.0.2 (2019-01-07)
 - [FIXED] Remove unnecessary `@types/nano` dependancy.
 
 # 3.0.1 (2018-11-22)

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "type": "git",
     "url": "git@github.com:cloudant/nodejs-cloudant.git"
   },
-  "version": "3.0.2-SNAPSHOT",
+  "version": "3.0.2",
   "author": {
     "name": "IBM Cloudant",
     "email": "support@cloudant.com"


### PR DESCRIPTION
# 3.0.2 (2019-01-07)
- [FIXED] Remove unnecessary `@types/nano` dependancy.