### PR TITLE
Check valid response before resume

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,6 @@
 # UNRELEASED
 - [NEW] Added option for client to authenticate with IAM token server.
+- [FIXED] Case where `.resume()` was called on an undefined response.
 
 # 3.0.2 (2019-01-07)
 - [FIXED] Remove unnecessary `@types/nano` dependancy.

--- a/lib/clientutils.js
+++ b/lib/clientutils.js
@@ -108,14 +108,16 @@ var processState = function(r, callback) {
     return;
   }
 
-  // pass response events/data to awaiting client
-  if (r.eventRelay) {
-    r.eventRelay.resume();
+  if (r.response) {
+    // pass response events/data to awaiting client
+    if (r.eventRelay) {
+      r.eventRelay.resume();
+    }
+    if (r.clientStream.destinations.length > 0) {
+      r.response.pipe(r.clientStream.passThroughReadable);
+    }
+    r.response.resume();
   }
-  if (r.clientStream.destinations.length > 0) {
-    r.response.pipe(r.clientStream.passThroughReadable);
-  }
-  r.response.resume();
 
   // [5] => Return response to awaiting client.
   callback(new Error('No retry requested')); // no retry

--- a/test/client.js
+++ b/test/client.js
@@ -201,6 +201,35 @@ describe('CloudantClient', function() {
     });
   });
 
+  describe('Error Handling', function() {
+    it('Propagate request error: Invalid protocol.', function(done) {
+      var cloudantClient = new Client();
+      cloudantClient.request('abc://localhost:5984', function(err) {
+        assert.equal(err.message, 'Invalid protocol: abc:');
+        done();
+      });
+    });
+
+    it('Propagate request error: Base URL must be type string.', function(done) {
+      var cloudantClient = new Client();
+      cloudantClient.request({ baseUrl: 123, url: '/_all_dbs' }, function(err) {
+        assert.equal(err.message, 'options.baseUrl must be a string');
+        done();
+      });
+    });
+
+    it('Propagate request error: `unix://` URL scheme is no longer supported.', function(done) {
+      var cloudantClient = new Client();
+      cloudantClient.request('unix://abc', function(err) {
+        assert.equal(
+          err.message,
+          '`unix://` URL scheme is no longer supported. Please use the format `http://unix:SOCKET:PATH`'
+        );
+        done();
+      });
+    });
+  });
+
   describe('aborts request', function() {
     it('during plugin execution phase', function(done) {
       if (process.env.NOCK_OFF) {


### PR DESCRIPTION
<!--
Thanks for your hard work, please ensure all items are complete before opening.
-->
## Checklist

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)
- [x] Added tests for code changes _or_ test/build only changes
- [x] Updated the change log file (`CHANGES.md`|`CHANGELOG.md`) _or_ test/build only changes
- [x] Completed the PR template below:

## Description
Check valid response before calling `.resume()`.

See #358 - Note this PR does not fix the issue. It propagates the correct error back to the user.

For example:
```js
myDB.attachment.insert(
  'doc-123456789'
  'pic1',
  fs.readFileSync('/tmp/empty_file.txt'), // Content-Length: 0
  'plain/txt',
  function(err) { console.log(err); }
);
```

_Output:_
```
{ Error: Argument error, options.body.
    at setContentLength (/dev/github.com/cloudant/nodejs-cloudant/node_modules/request/request.js:437:28)
    at Request.init (/dev/github.com/cloudant/nodejs-cloudant/node_modules/request/request.js:442:5)
...
```
<!--
Provide a short description; saving the detail for the `Approach` section

Also EITHER:
Link to issue this PR is resolving, use the Fixes #nnn form so that the
issue closes automatically when the PR merges e.g.:

Fixes #23

OR

For PRs without an associated issue and/or test/build issues

### 1. Steps to reproduce and the simplest code sample possible to demonstrate the issue
### 2. What you expected to happen
### 3. What actually happened
-->

## Approach
Check for a valid response object before attempting the resume.
<!--
Be brief: which component(s) of the code base does the fix focus on.

A place to note whether the part of the code base that is being worked is
particularly sensitive.
-->

## Schema & API Changes
No change.
<!--
EITHER:

- "No change"

OR

For public API (as opposed to internal) changes

- "Fixing bug in API, will change x in such-and-such way"
-->

## Security and Privacy
No change.
<!--
EITHER:

- "No change"

OR

"Making changes in e.g. auth|https|encryption|io
need to be careful about..."

-->

## Testing
Adds additional unit tests.
<!--
EITHER:

- Added new tests:
    - test x
    - test y
    - test z

OR

- Modified existing tests because ...

OR

- N/A build or packaging only changes

OR

In exceptional circumstances there may be a good reason we can't add automated
tests, for example if a specific device is required to reproduce a problem.

- No new tests because...
-->

## Monitoring and Logging
No change.
<!--
EITHER:

- "No change"

OR

- "Added new log line X..."
-->
