### PR TITLE
Prepare version 4.0.0 release

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,4 @@
-# UNRELEASED
+# 4.0.0 (2019-03-12)
 - [NEW] Added option for client to authenticate with IAM token server.
 - [FIXED] Add `vcapServiceName` configuration option to TS declarations.
 - [FIXED] Case where `.resume()` was called on an undefined response.

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "type": "git",
     "url": "git@github.com:cloudant/nodejs-cloudant.git"
   },
-  "version": "3.0.3-SNAPSHOT",
+  "version": "4.0.0",
   "author": {
     "name": "IBM Cloudant",
     "email": "support@cloudant.com"


### PR DESCRIPTION
# 4.0.0 (2019-03-12)
- [NEW] Added option for client to authenticate with IAM token server.
- [FIXED] Add `vcapServiceName` configuration option to TS declarations.
- [FIXED] Case where `.resume()` was called on an undefined response.
- [FIXED] Updated the default IAM token server URL.
- [BREAKING CHANGE] Nano 7 accepted a callback to the `*AsStream` functions, but
  the correct behaviour when using the `request` object from `*AsStream`
  functions is to use event handlers. Users of the `*AsStream` functions should
  ensure they are using event handlers not callbacks before moving to this
  version.
- [UPGRADED] Apache CouchDB Nano to a minimum of version 8 for `*AsStream`
  function fixes.