### PR TITLE
Removed sudo from `npm-cli-login` during publish

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -109,8 +109,8 @@ stage('Publish') {
         // 4. publish the build to NPM adding a snapshot tag if pre-release
         sh """
           ${isReleaseVersion ? '' : ('npm version --no-git-tag-version ' + version + '.' + env.BUILD_ID)}
-          sudo npm install -g npm-cli-login
-          npm-cli-login
+          npm install npm-cli-login
+          ./node_modules/.bin/npm-cli-login
           npm publish ${isReleaseVersion ? '' : '--tag snapshot'}
         """
       }


### PR DESCRIPTION
## Checklist

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)
- [x] Added tests for code changes _or_ test/build only changes
- [x] Updated the change log file (`CHANGES.md`|`CHANGELOG.md`) _or_ test/build only changes
- [x] Completed the PR template below:

## Description

Removed `sudo` and global install for `npm-cli-login` module during publish step.

### 1. Steps to reproduce and the simplest code sample possible to demonstrate the issue
Using new Jenkins executor image to run publication step.

### 2. What you expected to happen
Publication without errors

### 3. What actually happened
`EACCES` errors are observed during publish (e.g. similar to this for couchbackup):
https://cloudant-sdks-jenkins.swg-devops.com:8443/job/couchbackup/job/master/15/execution/node/103/log/

## Approach

The `sudo` installation of the `npm-cli-login` package is creating `$HOME/.npm` with `root` as the owner, causing subsequent errors when not running as root.

The package does not need to be installed globally and can therefore be installed without using `sudo` by qualifying the path used for the subsequent commands.

## Schema & API Changes

- "No change"

## Security and Privacy

- "No change"

## Testing

- N/A build or packaging only changes

## Monitoring and Logging

- "No change"