### PR TITLE
Don't add npm-cli-login as a dependency in the published package

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,5 @@
 # UNRELEASED
+- [FIXED] Remove unnecessary `npm-cli-login` dependency.
 
 # 4.1.0 (2019-05-14)
 - [NEW] Added partitioned database support.

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -109,7 +109,7 @@ stage('Publish') {
         // 4. publish the build to NPM adding a snapshot tag if pre-release
         sh """
           ${isReleaseVersion ? '' : ('npm version --no-git-tag-version ' + version + '.' + env.BUILD_ID)}
-          npm install npm-cli-login
+          npm install --no-save npm-cli-login
           ./node_modules/.bin/npm-cli-login
           npm publish ${isReleaseVersion ? '' : '--tag snapshot'}
         """


### PR DESCRIPTION
## Checklist

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)
- [x] Updated the change log file (`CHANGES.md`|`CHANGELOG.md`) _or_ test/build only changes
- [x] Completed the PR template below:

## Description

Running `npm install @cloudant/cloudant` should not install dependencies that are not listed in `package.json`. Starting from `npm@5`, `npm install foo` by default saves `foo` as a dependency, `npm-cli-login` is saved in the `package.json` right before jenkins publishes the package.

you can verify this with `npm view @cloudant/cloudant dependencies`.

## Approach

I've added `--no-save`, so `npm-cli-login` won't be saved in `dependencies`.

## Schema & API Changes

No change

## Security and Privacy

No change

## Testing

N/A

## Monitoring and Logging

No change