### PR TITLE
Development (#1)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,5 @@
 # 4.1.2 (2019-07-29)
-- [NEW] Plugins can now be loaded from outside of the 'plugins/' directory
+- [FIXED] Plugins can now be loaded from outside of the 'plugins/' directory
 
 # 4.1.1 (2019-06-17)
 - [FIXED] Remove unnecessary `npm-cli-login` dependency.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,6 @@
+# 4.1.2 (2019-07-29)
+- [NEW] Plugins can now be loaded from outside of the 'plugins/' directory
+
 # 4.1.1 (2019-06-17)
 - [FIXED] Remove unnecessary `npm-cli-login` dependency.
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -102,7 +102,7 @@ class CloudantClient {
           var pluginName = Object.keys(plugin)[0];
 
           try {
-            Plugin = require('../plugins/' + pluginName);
+            Plugin = require(self._buildPluginPath(pluginName));
           } catch (e) {
             throw new Error(`Failed to load plugin - ${e.message}`);
           }
@@ -120,7 +120,7 @@ class CloudantClient {
           }
 
           try {
-            Plugin = require('../plugins/' + plugin);
+            Plugin = require(self._buildPluginPath(plugin));
           } catch (e) {
             throw new Error(`Failed to load plugin - ${e.message}`);
           }

--- a/lib/client.js
+++ b/lib/client.js
@@ -17,6 +17,7 @@ const async = require('async');
 const concat = require('concat-stream');
 const debug = require('debug')('cloudant:client');
 const EventRelay = require('./eventrelay.js');
+const path = require('path');
 const PassThroughDuplex = require('./passthroughduplex.js');
 const pkg = require('../package.json');
 const utils = require('./clientutils.js');
@@ -145,6 +146,21 @@ class CloudantClient {
         self._pluginIds.push(Plugin.id);
       }
     });
+  }
+
+  _buildPluginPath(name) {
+    // Only a plugin name was provided: use plugin directory
+    if (path.basename(name) === name) {
+      return '../plugins/' + name;
+    }
+
+    // An absolute path was provided
+    if (path.isAbsolute(name)) {
+      return name;
+    }
+
+    // A relative path was provided
+    return path.join(process.cwd(), name);
   }
 
   _initClient(client) {

--- a/test/client.js
+++ b/test/client.js
@@ -18,6 +18,7 @@
 const assert = require('assert');
 const Client = require('../lib/client.js');
 const nock = require('./nock.js');
+const path = require('path');
 const stream = require('stream');
 const testPlugin = require('./fixtures/testplugins.js');
 const uuidv4 = require('uuid/v4'); // random
@@ -86,6 +87,21 @@ describe('CloudantClient', function() {
   });
 
   describe('plugin support', function() {
+    it('get plugin path by name', function() {
+      var cloudantClient = new Client();
+      assert.equal(cloudantClient._buildPluginPath('dummy-plugin'), '../plugins/dummy-plugin');
+    });
+
+    it('get plugin path by relative path', function() {
+      var cloudantClient = new Client();
+      assert.equal(cloudantClient._buildPluginPath('./dummy-plugin'), path.join(process.cwd(), 'dummy-plugin'));
+    });
+
+    it('get plugin path by absolute path', function() {
+      var cloudantClient = new Client();
+      assert.equal(cloudantClient._buildPluginPath('/plugins/dummy-plugin'), '/plugins/dummy-plugin');
+    });
+
     it('adds cookie authentication plugin if no other plugins are specified', function() {
       var cloudantClient = new Client();
       assert.equal(cloudantClient._plugins.length, 1);

--- a/test/client.js
+++ b/test/client.js
@@ -102,6 +102,14 @@ describe('CloudantClient', function() {
       assert.equal(cloudantClient._buildPluginPath('/plugins/dummy-plugin'), '/plugins/dummy-plugin');
     });
 
+    it('load plugin from custom path', function() {
+      let ownPlugin = 'test/fixtures/testplugin.js';
+      var cloudantClient = new Client({
+        plugins: [ ownPlugin ]
+      });
+      assert.equal(cloudantClient._plugins.length, 1);
+    });
+
     it('adds cookie authentication plugin if no other plugins are specified', function() {
       var cloudantClient = new Client();
       assert.equal(cloudantClient._plugins.length, 1);

--- a/test/fixtures/testplugin.js
+++ b/test/fixtures/testplugin.js
@@ -1,0 +1,23 @@
+// Copyright © 2017, 2018 IBM Corp. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+'use strict';
+
+const BasePlugin = require('../../plugins/base.js');
+
+class TestPlugin extends BasePlugin {
+}
+
+TestPlugin.id = 'test';
+
+module.exports = TestPlugin;


### PR DESCRIPTION
Allow plugins to be loaded from an absolute or relative path

<!--
Thanks for your hard work, please ensure all items are complete before opening.
-->
## Checklist

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)
- [x] Added tests for code changes _or_ test/build only changes
- [x] Updated the change log file (`CHANGES.md`|`CHANGELOG.md`) _or_ test/build only changes
- [x] Completed the PR template below:

## Description
Allow to load plugins based on a relative or absolute path.

## Approach
Right now plugins can only be loaded if they reside in the `plugins/` directory of the Cloudant NPM module. With this change it's possible to load a plugin from an arbitrary file system location.

Example:
```
let cloudantPluginPath = path.join(process.cwd(), "myPlugin.js");
dbConfig.plugins = [{
  [cloudantPluginPath]: {
    myParam: 42
  }
}];
```

## Schema & API Changes
No change

## Security and Privacy
No Change

## Testing
- Added new tests:
    - `plugin support.get plugin path by name`
    - `plugin support.get plugin path by relative path`
    - `plugin support.get plugin path by absolute path`

## Monitoring and Logging
No change
