### PR TITLE
Prepare version 4.2.0 release.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,4 @@
-# UNRELEASED
+# 4.2.0 (2019-08-27)
 - [NEW] Added option to set new IAM API key.
 - [FIXED] Allow plugins to be loaded from outside the 'plugins/' directory.
 - [FIXED] Retry bad IAM token requests.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloudant/cloudant",
-  "version": "4.1.2-SNAPSHOT",
+  "version": "4.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "type": "git",
     "url": "git@github.com:cloudant/nodejs-cloudant.git"
   },
-  "version": "4.1.2-SNAPSHOT",
+  "version": "4.2.0",
   "author": {
     "name": "IBM Cloudant",
     "email": "support@cloudant.com"


### PR DESCRIPTION
# 4.2.0 (2019-08-27)
- [NEW] Added option to set new IAM API key.
- [FIXED] Allow plugins to be loaded from outside the 'plugins/' directory.
- [FIXED] Retry bad IAM token requests.