### PR TITLE
Prepare version 4.2.1 release.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,4 @@
-# UNRELEASED
+# 4.2.1 (2019-08-29)
 - [FIXED] Include all built-in plugin modules in webpack bundle.
 
 # 4.2.0 (2019-08-27)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloudant/cloudant",
-  "version": "4.2.1-SNAPSHOT",
+  "version": "4.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "type": "git",
     "url": "git@github.com:cloudant/nodejs-cloudant.git"
   },
-  "version": "4.2.1-SNAPSHOT",
+  "version": "4.2.1",
   "author": {
     "name": "IBM Cloudant",
     "email": "support@cloudant.com"


### PR DESCRIPTION
# 4.2.1 (2019-08-29)
- [FIXED] Include all built-in plugin modules in webpack bundle.