### PR TITLE
Replace package `lockfile` with internal mutex implementation.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
   temporary.
 - [FIXED] Ensure IAM API key can be correctly changed.
 - [FIXED] Callback with an error when a user cannot be authenticated using IAM.
+- [REMOVED] Remove dependency lockfile. Use internal Mutex class instead.
 
 # 4.2.1 (2019-08-29)
 - [FIXED] Include all built-in plugin modules in webpack bundle.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@
 - [FIXED] Ensure IAM API key can be correctly changed.
 - [FIXED] Callback with an error when a user cannot be authenticated using IAM.
 - [REMOVED] Remove dependency lockfile. Use internal Mutex class instead.
+- [IMPROVED] Reduce the authentication lock wait timeout default to 500ms.
 
 # 4.2.1 (2019-08-29)
 - [FIXED] Include all built-in plugin modules in webpack bundle.

--- a/lib/mutex.js
+++ b/lib/mutex.js
@@ -1,0 +1,71 @@
+// Copyright © 2019 IBM Corp. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+'use strict';
+
+const debug = require('debug')('cloudant:mutex');
+
+class Mutex {
+  constructor() {
+    this._isLocked = false;
+    this._waiting = [];
+  }
+
+  get isLocked() {
+    return this._isLocked;
+  }
+
+  lock(ttl, callback) {
+    if (!this._isLocked) {
+      this._isLocked = true;
+      callback();
+      return;
+    }
+
+    var timer;
+    this._waiting.push(() => {
+      clearTimeout(timer);
+
+      if (!callback) {
+        this.unlock();
+        return;
+      }
+
+      callback();
+      callback = null;
+    });
+
+    timer = setTimeout(() => {
+      if (callback) {
+        callback(new Error('Timed out acquiring lock.'));
+        callback = null;
+      }
+    }, ttl);
+  }
+
+  unlock() {
+    if (!this._isLocked) {
+      debug('Attempted to unlock an already unlocked mutex.');
+      return;
+    }
+
+    let waiter = this._waiting.shift();
+    if (waiter) {
+      waiter();
+    } else {
+      this._isLocked = false;
+    }
+  }
+}
+
+module.exports = Mutex;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1463,11 +1463,6 @@
         }
       }
     },
-    "lockfile": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/lockfile/-/lockfile-1.0.3.tgz",
-      "integrity": "sha1-Jjj8OaAzHpysGgS3F5mTHJxQ33k="
-    },
     "lodash": {
       "version": "4.17.15",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
@@ -1722,7 +1717,8 @@
     "os-tmpdir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+      "dev": true
     },
     "p-limit": {
       "version": "1.3.0",
@@ -2281,6 +2277,7 @@
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
       "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "dev": true,
       "requires": {
         "os-tmpdir": "~1.0.2"
       }

--- a/package.json
+++ b/package.json
@@ -27,10 +27,8 @@
     "async": "2.1.2",
     "concat-stream": "^1.6.0",
     "debug": "^3.1.0",
-    "lockfile": "1.0.3",
     "nano": "^8.1.0",
-    "request": "^2.81.0",
-    "tmp": "0.0.33"
+    "request": "^2.81.0"
   },
   "devDependencies": {
     "dotenv": "2.0.0",
@@ -48,6 +46,7 @@
     "mocha": "^5.1.1",
     "nock": "^9.2.5",
     "should": "6.0.3",
+    "tmp": "0.0.33",
     "typescript": "^2.8.3",
     "uuid": "^3.0.1"
   },

--- a/plugins/cookieauth.js
+++ b/plugins/cookieauth.js
@@ -145,7 +145,7 @@ class CookiePlugin extends BasePlugin {
   refreshCookie(state, callback) {
     var self = this;
 
-    self.withLock(self._cfg.cookieLockWaitMsecs || 1000, function(error, done) {
+    self.withLock(self._cfg.cookieLockWaitMsecs || 500, function(error, done) {
       if (error) {
         debug(`Failed to acquire lock: ${error}`); // refresh cookie without lock
       }

--- a/plugins/cookieauth.js
+++ b/plugins/cookieauth.js
@@ -145,10 +145,7 @@ class CookiePlugin extends BasePlugin {
   refreshCookie(state, callback) {
     var self = this;
 
-    self.withLock({
-      stale: self._cfg.cookieLockStaleMsecs || 1500, // 1.5 secs
-      wait: self._cfg.cookieLockWaitMsecs || 1000 // 1 sec
-    }, function(error, done) {
+    self.withLock(self._cfg.cookieLockWaitMsecs || 1000, function(error, done) {
       if (error) {
         debug(`Failed to acquire lock: ${error}`); // refresh cookie without lock
       }

--- a/plugins/iamauth.js
+++ b/plugins/iamauth.js
@@ -109,7 +109,7 @@ class IAMPlugin extends BasePlugin {
       return callback(new Error('Unspecified base URL'));
     }
 
-    self.withLock(cfg.iamLockWaitMsecs || 2000, function(error, done) {
+    self.withLock(cfg.iamLockWaitMsecs || 500, function(error, done) {
       if (state.stash.newApiKey) {
         debug('Refreshing session with new IAM API key.');
         state.stash.newApiKey = false;

--- a/plugins/iamauth.js
+++ b/plugins/iamauth.js
@@ -109,10 +109,7 @@ class IAMPlugin extends BasePlugin {
       return callback(new Error('Unspecified base URL'));
     }
 
-    self.withLock({
-      stale: cfg.iamLockStaleMsecs || 2500, // 2.5 secs
-      wait: cfg.iamLockWaitMsecs || 2000 // 2 secs
-    }, function(error, done) {
+    self.withLock(cfg.iamLockWaitMsecs || 2000, function(error, done) {
       if (state.stash.newApiKey) {
         debug('Refreshing session with new IAM API key.');
         state.stash.newApiKey = false;

--- a/test/mutex.js
+++ b/test/mutex.js
@@ -1,0 +1,105 @@
+// Copyright © 2019 IBM Corp. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/* global describe it */
+'use strict';
+
+const assert = require('assert');
+
+const Mutex = require('../lib/mutex');
+
+describe('Mutex', function() {
+  it('can acquire the mutex', function(done) {
+    var m = new Mutex();
+    m.lock(1, (err) => {
+      assert.ok(m.isLocked);
+      m.unlock();
+      assert.ok(m.isLocked === false);
+      done(err);
+    });
+  });
+
+  it('can unlock a mutex multiple times without error', function(done) {
+    var m = new Mutex();
+    m.lock(1, (err) => {
+      assert.ok(m.isLocked);
+      m.unlock();
+      assert.ok(m.isLocked === false);
+      m.unlock();
+      assert.ok(m.isLocked === false);
+      m.unlock();
+      assert.ok(m.isLocked === false);
+      done(err);
+    });
+  });
+
+  it('times out correctly when attempting to acquire a busy lock', function(done) {
+    var acquireTimedOut = false;
+    var m = new Mutex();
+
+    m.lock(1, (err) => {
+      assert.ok(m.isLocked);
+      setTimeout(() => {
+        assert.ok(acquireTimedOut);
+        assert.ok(m.isLocked);
+        m.unlock();
+        assert.ok(m.isLocked === false);
+        done(err);
+      }, 500);
+    });
+
+    m.lock(250, (err) => {
+      assert.equal(err.message, 'Timed out acquiring lock.');
+      acquireTimedOut = true;
+    });
+  });
+
+  it('waits correctly when attempting to acquire a busy lock', function(done) {
+    var acquiredLockCount = 0;
+    var m = new Mutex();
+
+    var startTs = (new Date()).getTime();
+
+    // make 100 lock acquires
+    for (let i = 1; i < 101; i++) {
+      if (i === 100) { // last lock
+        m.lock(15 * i, (err) => {
+          assert.ifError(err);
+          assert.ok(m.isLocked);
+          acquiredLockCount += 1;
+          setTimeout(() => {
+            assert.ok(m.isLocked);
+            m.unlock();
+            assert.ok(m.isLocked === false);
+            assert.equal(acquiredLockCount, 100);
+            let now = (new Date()).getTime();
+            assert.ok(now - startTs > 1000); // 100 locks * 10ms
+            done();
+          }, 10);
+        });
+      } else {
+        m.lock(15 * i, (err) => {
+          assert.ifError(err);
+          assert.ok(m.isLocked);
+          acquiredLockCount += 1;
+          setTimeout(() => {
+            assert.ok(m.isLocked);
+            m.unlock();
+            assert.ok(m.isLocked); // the wait array is not empty
+          }, 10);
+        });
+      }
+    }
+  });
+});


### PR DESCRIPTION
## Checklist

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)
- [x] Added tests for code changes _or_ test/build only changes
- [x] Updated the change log file (`CHANGES.md`|`CHANGELOG.md`) _or_ test/build only changes
- [x] Completed the PR template below:

## Description
Replace package `lockfile` with internal mutex implementation.
<!--
Provide a short description; saving the detail for the `Approach` section

Also EITHER:
Link to issue this PR is resolving, use the Fixes #nnn form so that the
issue closes automatically when the PR merges e.g.:

Fixes #23

OR

For PRs without an associated issue and/or test/build issues

### 1. Steps to reproduce and the simplest code sample possible to demonstrate the issue
### 2. What you expected to happen
### 3. What actually happened
-->

## Approach
The new Mutex class provides a basic lock that can be used to prevent the simultaneous access to a resource.

<!--
Be brief: which component(s) of the code base does the fix focus on.

A place to note whether the part of the code base that is being worked is
particularly sensitive.
-->

## Schema & API Changes
No change.
<!--
EITHER:

- "No change"

OR

For public API (as opposed to internal) changes

- "Fixing bug in API, will change x in such-and-such way"
-->

## Security and Privacy
No change.
<!--
EITHER:

- "No change"

OR

"Making changes in e.g. auth|https|encryption|io
need to be careful about..."

-->

## Testing
Includes additional unit testing.
<!--
EITHER:

- Added new tests:
    - test x
    - test y
    - test z

OR

- Modified existing tests because ...

OR

- N/A build or packaging only changes

OR

In exceptional circumstances there may be a good reason we can't add automated
tests, for example if a specific device is required to reproduce a problem.

- No new tests because...
-->

## Monitoring and Logging
Adds a new log class `cloudant:mutex`.
<!--
EITHER:

- "No change"

OR

- "Added new log line X..."
-->