### PR TITLE
Disable cookie authentication if credentials are missing.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,8 @@
 - [FIXED] Ensure IAM API key can be correctly changed.
 - [FIXED] Callback with an error when a user cannot be authenticated using IAM.
 - [FIXED] Ensure authorization tokens are not unnecessarily requested.
+- [IMPROVED] Do not apply cookie authentication by default in the case that no
+  credentials are provided.
 - [IMPROVED] Preemptively renew authorization tokens that are due to expire.
 
 # 4.2.1 (2019-08-29)

--- a/cloudant.js
+++ b/cloudant.js
@@ -294,7 +294,7 @@ function Cloudant(options, callback) {
   nano.generate_api_key = generate_api_key; // eslint-disable-line camelcase
 
   if (callback) {
-    nano.cc._addPlugins('cookieauth');
+    nano.cc._addPlugins({ cookieauth: { errorOnNoCreds: false } });
     nano.ping(function(error, pong) {
       if (error) {
         callback(error);

--- a/lib/client.js
+++ b/lib/client.js
@@ -51,7 +51,7 @@ class CloudantClient {
       plugins = [ { iamauth: { iamApiKey: self._cfg.creds.iamApiKey } } ];
     } else if (typeof this._cfg.plugins === 'undefined') {
       // => No plugins specified - Add 'cookieauth' plugin.
-      plugins = [ 'cookieauth' ];
+      plugins = [ { cookieauth: { errorOnNoCreds: false } } ];
     }
 
     // Add user specified plugins.

--- a/lib/clientutils.js
+++ b/lib/clientutils.js
@@ -131,6 +131,9 @@ var runHooks = function(hookName, r, data, end) {
     async.eachSeries(r.plugins, function(plugin, done) {
       if (typeof plugin[hookName] !== 'function') {
         done(); // no hooks for plugin
+      } else if (plugin.disabled) {
+        debug(`Skipping hook ${hookName} for disabled plugin '${plugin.id}'.`);
+        done();
       } else {
         debug(`Running hook ${hookName} for plugin '${plugin.id}'.`);
         var oldState = Object.assign({}, r.state);

--- a/plugins/base.js
+++ b/plugins/base.js
@@ -29,11 +29,21 @@ class BasePlugin {
   constructor(client, cfg) {
     this._client = client;
     this._cfg = cfg;
+    this._disabled = false;
     this._lockFile = tmp.tmpNameSync({ postfix: '.lock' });
   }
 
   get id() {
     return this.constructor.id;
+  }
+
+  get disabled() {
+    return this._disabled;
+  }
+
+  // Disable a plugin to prevent all hooks from being executed.
+  set disabled(disabled) {
+    this._disabled = disabled;
   }
 
   // NOOP Base Hooks

--- a/plugins/cookieauth.js
+++ b/plugins/cookieauth.js
@@ -25,14 +25,22 @@ const CookieTokenManager = require('../lib/tokens/CookieTokenManager');
  */
 class CookiePlugin extends BasePlugin {
   constructor(client, cfg) {
-    cfg = Object.assign({ autoRenew: true }, cfg);
+    cfg = Object.assign({
+      autoRenew: true,
+      errorOnNoCreds: true
+    }, cfg);
 
     super(client, cfg);
 
     let sessionUrl = new u.URL(cfg.serverUrl);
     sessionUrl.pathname = '/_session';
     if (!sessionUrl.username || !sessionUrl.password) {
-      throw new Error('Credentials are required for cookie authentication.');
+      if (cfg.errorOnNoCreds) {
+        throw new Error('Credentials are required for cookie authentication.');
+      }
+      debug('Missing credentials for cookie authentication. Permanently disabling plugin.');
+      this.disabled = true;
+      return;
     }
 
     this._jar = request.jar();


### PR DESCRIPTION
<!--
Thanks for your hard work, please ensure all items are complete before opening.
-->
## Checklist

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)
- [x] Added tests for code changes _or_ test/build only changes
- [x] Updated the change log file (`CHANGES.md`|`CHANGELOG.md`) _or_ test/build only changes
- [x] Completed the PR template below:

## Description
Disable cookie authentication if credentials are missing.
<!--
Provide a short description; saving the detail for the `Approach` section

Also EITHER:
Link to issue this PR is resolving, use the Fixes #nnn form so that the
issue closes automatically when the PR merges e.g.:

Fixes #23

OR

For PRs without an associated issue and/or test/build issues

### 1. Steps to reproduce and the simplest code sample possible to demonstrate the issue
### 2. What you expected to happen
### 3. What actually happened
-->

## Approach
If credentials are missing then set a 'disabled' property on the cookie plugin to prevent hooks from being executed.
<!--
Be brief: which component(s) of the code base does the fix focus on.

A place to note whether the part of the code base that is being worked is
particularly sensitive.
-->

## Schema & API Changes
No change.
<!--
EITHER:

- "No change"

OR

For public API (as opposed to internal) changes

- "Fixing bug in API, will change x in such-and-such way"
-->

## Security and Privacy
No change.
<!--
EITHER:

- "No change"

OR

"Making changes in e.g. auth|https|encryption|io
need to be careful about..."

-->

## Testing
Includes additional unit tests.
<!--
EITHER:

- Added new tests:
    - test x
    - test y
    - test z

OR

- Modified existing tests because ...

OR

- N/A build or packaging only changes

OR

In exceptional circumstances there may be a good reason we can't add automated
tests, for example if a specific device is required to reproduce a problem.

- No new tests because...
-->

## Monitoring and Logging
No change.
<!--
EITHER:

- "No change"

OR

- "Added new log line X..."
-->
