### PR TITLE
Prepare version 4.2.2 release.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,4 @@
-# UNRELEASED
+# 4.2.2 (2019-10-23)
 - [FIXED] Stopped disabling the IAM auth plugin after failed IAM
   authentications. Subsequent requests will re-request authorization,
   potentially failing again if the original authentication failure was not

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloudant/cloudant",
-  "version": "4.2.2-SNAPSHOT",
+  "version": "4.2.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "type": "git",
     "url": "git@github.com:cloudant/nodejs-cloudant.git"
   },
-  "version": "4.2.2-SNAPSHOT",
+  "version": "4.2.2",
   "author": {
     "name": "IBM Cloudant",
     "email": "support@cloudant.com"


### PR DESCRIPTION
# 4.2.2 (2019-10-23)
- [FIXED] Stopped disabling the IAM auth plugin after failed IAM
  authentications. Subsequent requests will re-request authorization,
  potentially failing again if the original authentication failure was not
  temporary.
- [FIXED] Ensure IAM API key can be correctly changed.
- [FIXED] Callback with an error when a user cannot be authenticated using IAM.
- [FIXED] Ensure authorization tokens are not unnecessarily requested.
- [IMPROVED] Do not apply cookie authentication by default in the case that no
  credentials are provided.
- [IMPROVED] Preemptively renew authorization tokens that are due to expire.