### PR TITLE
Used application/json for session POST

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # UNRELEASED
 - [FIXED] Expose BasePlugin.
+- [FIXED] Prevent double encoding of credentials passed in URL user information
+  when using the `cookieauth` plugin.
+- [IMPROVED] Documented the characters that are required to be encoded in URL
+  user information.
 - [IMPROVED] Documented the legacy compatibility behaviour that always adds the
   `cookieauth` plugin when using the initialization callback functionality.
 

--- a/README.md
+++ b/README.md
@@ -156,14 +156,20 @@ var Cloudant = require('@cloudant/cloudant');
 var cloudant = Cloudant("http://MYUSERNAME:MYPASSWORD@localhost:5984");
 ~~~
 
-**Note**: If you pass credentials in the user information subcomponent of the URL
-then they must be [percent encoded](https://tools.ietf.org/html/rfc3986#section-3.2.1).
-Specifically the characters `: / ? # [ ] @ %` _MUST_ be precent-encoded, other
-characters _MAY_ be percent encoded.
+**Note**: It is preferred to pass credentials using the `account`/`username` and
+`password` configuration options rather than as part of the URL. However, if you
+choose to pass credentials in the user information subcomponent of the URL then
+they must be [percent encoded](https://tools.ietf.org/html/rfc3986#section-3.2.1).
+Specifically within either the username or passowrd the characters `: / ? # [ ] @ %`
+_MUST_ be precent-encoded, other characters _MAY_ be percent encoded.
+For example for the username `user123` and password `colon:at@321`:
+```
+https://user123:colon%3aat%40321@localhost:5984
+```
 Credentials must not be percent encoded when passing them via other configuration
 options besides `url`.
 
-**Note**: If you pass in a `username`, `password`, and `url` that contains
+If you pass in `username` and `password` options and a `url` that contains
 credentials, the `username` and `password` will supercede the credentials within
 the `url`.  For example, `myusername` and `mypassword` will be used in the code
 below during authentication:

--- a/README.md
+++ b/README.md
@@ -156,6 +156,13 @@ var Cloudant = require('@cloudant/cloudant');
 var cloudant = Cloudant("http://MYUSERNAME:MYPASSWORD@localhost:5984");
 ~~~
 
+**Note**: If you pass credentials in the user information subcomponent of the URL
+then they must be [percent encoded](https://tools.ietf.org/html/rfc3986#section-3.2.1).
+Specifically the characters `: / ? # [ ] @ %` _MUST_ be precent-encoded, other
+characters _MAY_ be percent encoded.
+Credentials must not be percent encoded when passing them via other configuration
+options besides `url`.
+
 **Note**: If you pass in a `username`, `password`, and `url` that contains
 credentials, the `username` and `password` will supercede the credentials within
 the `url`.  For example, `myusername` and `mypassword` will be used in the code

--- a/lib/tokens/CookieTokenManager.js
+++ b/lib/tokens/CookieTokenManager.js
@@ -29,7 +29,8 @@ class CookieTokenManager extends TokenManager {
     this._client({
       url: this._sessionUrl,
       method: 'POST',
-      form: {
+      json: true,
+      body: {
         name: this._username,
         password: this._password
       },

--- a/plugins/cookieauth.js
+++ b/plugins/cookieauth.js
@@ -49,8 +49,9 @@ class CookiePlugin extends BasePlugin {
       client,
       this._jar,
       u.format(sessionUrl, {auth: false}),
-      sessionUrl.username,
-      sessionUrl.password
+      // Extract creds from URL and decode
+      decodeURIComponent(sessionUrl.username),
+      decodeURIComponent(sessionUrl.password)
     );
 
     if (cfg.autoRenew) {

--- a/test/plugins/cookieauth.js
+++ b/test/plugins/cookieauth.js
@@ -21,10 +21,10 @@ const nock = require('../nock.js');
 const uuidv4 = require('uuid/v4'); // random
 
 const ME = process.env.cloudant_username || 'nodejs';
-const PASSWORD = process.env.cloudant_password || 'sjedon';
+const PASSWORD = process.env.cloudant_password || 'sjedon!@#"£$%^&*()';
 const SERVER = process.env.SERVER_URL || `https://${ME}.cloudant.com`;
 const SERVER_NO_PROTOCOL = SERVER.replace(/^https?:\/\//, '');
-const SERVER_WITH_CREDS = `https://${ME}:${PASSWORD}@${SERVER_NO_PROTOCOL}`;
+const SERVER_WITH_CREDS = `https://${ME}:${encodeURIComponent(PASSWORD)}@${SERVER_NO_PROTOCOL}`;
 const DBNAME = `/nodejs-cloudant-${uuidv4()}`;
 const COOKIEAUTH_PLUGIN = [ { cookieauth: { autoRenew: false } } ];
 


### PR DESCRIPTION
## Checklist

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)
- [x] Added tests for code changes _or_ test/build only changes
- [x] Updated the change log file (`CHANGES.md`|`CHANGELOG.md`) _or_ test/build only changes
- [x] Completed the PR template below:

## Description

Use `application/json` for `_session` POST of cookie auth

### 1. Steps to reproduce and the simplest code sample possible to demonstrate the issue
Pass a `url` containing percent-encoded user information.
### 2. What you expected to happen
cookieauth plugin session authentication to work correctly
### 3. What actually happened
`401 unauthorized` because the credentials were double encoded.

## Approach

* Decoded credentials from URL before passing to `CookieTokenManager`.
    * Prevents double encoding if passed in a form body
* Modified CookieTokenManager to use `json` body instead of `form` encoded anyway
* Improved documentation of characters that must be encoded.

## Schema & API Changes

- No change

## Security and Privacy

Insignificant changes to handling of credentials
* For cookieauth credentials are now posted in a JSON body instead of as form encoded data, but it is the same request body as previously (i.e. if the server is https then the body containing the creds will be encrypted)
* Preferentially credentials should be passed in the `username` and `password` configuration options instead, but in the case where they are passed in the URL user info it is now documented what characters must be encoded.

## Testing

- Modified existing `cookieauth` tests to use a password with special characters.
- Additional manual testing of credentials passed in URL.

## Monitoring and Logging

- "No change"
