### PR TITLE
Prepare 4.2.3 release

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,4 @@
-# UNRELEASED
+# 4.2.3 (2019-12-05)
 - [FIXED] Expose BasePlugin.
 - [FIXED] Prevent double encoding of credentials passed in URL user information
   when using the `cookieauth` plugin.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloudant/cloudant",
-  "version": "4.2.3-SNAPSHOT",
+  "version": "4.2.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "type": "git",
     "url": "git@github.com:cloudant/nodejs-cloudant.git"
   },
-  "version": "4.2.3-SNAPSHOT",
+  "version": "4.2.3",
   "author": {
     "name": "IBM Cloudant",
     "email": "support@cloudant.com"


### PR DESCRIPTION
# Proposed 4.2.3 release

# Changes

# 4.2.3 (2019-12-05)
- [FIXED] Expose BasePlugin.
- [FIXED] Prevent double encoding of credentials passed in URL user information
  when using the `cookieauth` plugin.
- [IMPROVED] Documented the characters that are required to be encoded in URL
  user information.
- [IMPROVED] Documented the legacy compatibility behaviour that always adds the
  `cookieauth` plugin when using the initialization callback functionality.
