### PR TITLE
Concatenate streaming data in client tests

### DIFF
--- a/test/client.js
+++ b/test/client.js
@@ -955,7 +955,7 @@ describe('CloudantClient', function() {
           method: 'GET'
         };
 
-        var responseString = '';
+        var responseData = '';
         cloudantClient.request(options)
           .on('error', function(err) {
             assert.fail(`Unexpected error: ${err}`);
@@ -964,10 +964,10 @@ describe('CloudantClient', function() {
             assert.equal(resp.statusCode, 200);
           })
           .on('data', function(data) {
-            responseString += data;
+            responseData += data;
           })
           .on('end', function() {
-            assert.ok(responseString.toString('utf8').indexOf('"doc_count":1') > -1);
+            assert.ok(responseData.toString('utf8').indexOf('"doc_count":1') > -1);
             mocks.done();
             done();
           });
@@ -1015,7 +1015,7 @@ describe('CloudantClient', function() {
           auth: { username: ME, password: PASSWORD },
           method: 'GET'
         };
-        var responseString = '';
+        var responseData = '';
         cloudantClient.request(options)
           .on('error', function(err) {
             assert.fail(`Unexpected error: ${err}`);
@@ -1024,10 +1024,10 @@ describe('CloudantClient', function() {
             assert.equal(resp.statusCode, 200);
           })
           .on('data', function(data) {
-            responseString += data;
+            responseData += data;
           })
           .on('end', function() {
-            assert.ok(responseString.toString('utf8').indexOf('"doc_count":1') > -1);
+            assert.ok(responseData.toString('utf8').indexOf('"doc_count":1') > -1);
             assert.equal(cloudantClient._plugins[0].onRequestCallCount, 1);
             assert.equal(cloudantClient._plugins[0].onErrorCallCount, 0);
             assert.equal(cloudantClient._plugins[0].onResponseCallCount, 1);
@@ -1085,7 +1085,7 @@ describe('CloudantClient', function() {
           auth: { username: ME, password: PASSWORD },
           method: 'GET'
         };
-        var responseString = '';
+        var responseData = '';
         cloudantClient.request(options)
           .on('error', function(err) {
             assert.fail(`Unexpected error: ${err}`);
@@ -1094,10 +1094,10 @@ describe('CloudantClient', function() {
             assert.equal(resp.statusCode, 200);
           })
           .on('data', function(data) {
-            responseString += data;
+            responseData += data;
           })
           .on('end', function() {
-            assert.ok(responseString.toString('utf8').indexOf('"doc_count":1') > -1);
+            assert.ok(responseData.toString('utf8').indexOf('"doc_count":1') > -1);
             assert.equal(cloudantClient._plugins[0].onRequestCallCount, 1);
             assert.equal(cloudantClient._plugins[0].onErrorCallCount, 0);
             assert.equal(cloudantClient._plugins[0].onResponseCallCount, 1);
@@ -1165,7 +1165,7 @@ describe('CloudantClient', function() {
           auth: { username: ME, password: PASSWORD },
           method: 'HEAD' // ComplexPlugin1 will set method to 'PUT'
         };
-        var responseString = '';
+        var responseData = '';
         var startTs = (new Date()).getTime();
         cloudantClient.request(options)
           .on('error', function(err) {
@@ -1176,10 +1176,10 @@ describe('CloudantClient', function() {
             assert.equal(resp.request.headers.ComplexPlugin1, 'foo');
           })
           .on('data', function(data) {
-            responseString += data;
+            responseData += data;
           })
           .on('end', function() {
-            assert.ok(responseString.toString('utf8').indexOf('"error":"file_exists"') > -1);
+            assert.ok(responseData.toString('utf8').indexOf('"error":"file_exists"') > -1);
             assert.equal(cloudantClient._plugins[0].onRequestCallCount, 10);
             assert.equal(cloudantClient._plugins[0].onErrorCallCount, 0);
             assert.equal(cloudantClient._plugins[0].onResponseCallCount, 10);
@@ -1249,7 +1249,7 @@ describe('CloudantClient', function() {
           auth: { username: ME, password: PASSWORD },
           method: 'POST' // ComplexPlugin2 will set method to 'GET'
         };
-        var responseString = '';
+        var responseData = '';
         cloudantClient.request(options)
           .on('error', function(err) {
             assert.fail(`Unexpected error: ${err}`);
@@ -1259,10 +1259,10 @@ describe('CloudantClient', function() {
             assert.equal(resp.request.headers.ComplexPlugin2, 'bar');
           })
           .on('data', function(data) {
-            responseString += data;
+            responseData += data;
           })
           .on('end', function() {
-            assert.ok(responseString.toString('utf8').indexOf('"error":"unauthorized"') > -1);
+            assert.ok(responseData.toString('utf8').indexOf('"error":"unauthorized"') > -1);
             assert.equal(cloudantClient._plugins[0].onRequestCallCount, 2);
             assert.equal(cloudantClient._plugins[0].onErrorCallCount, 0);
             assert.equal(cloudantClient._plugins[0].onResponseCallCount, 2);
@@ -1292,7 +1292,7 @@ describe('CloudantClient', function() {
           auth: { username: ME, password: PASSWORD },
           method: 'DELETE' // ComplexPlugin2 will set method to 'GET'
         };
-        var responseString = '';
+        var responseData = '';
         cloudantClient.request(options)
           .on('error', function(err) {
             assert.fail(`Unexpected error: ${err}`);
@@ -1301,10 +1301,10 @@ describe('CloudantClient', function() {
             assert.equal(resp.statusCode, 200);
           })
           .on('data', function(data) {
-            responseString += data;
+            responseData += data;
           })
           .on('end', function() {
-            assert.ok(responseString.toString('utf8').indexOf('"ok":true') > -1);
+            assert.ok(responseData.toString('utf8').indexOf('"ok":true') > -1);
             assert.equal(cloudantClient._plugins[0].onRequestCallCount, 1);
             assert.equal(cloudantClient._plugins[0].onErrorCallCount, 1);
             assert.equal(cloudantClient._plugins[0].onResponseCallCount, 0);
@@ -1339,7 +1339,7 @@ describe('CloudantClient', function() {
           auth: { username: ME, password: PASSWORD },
           method: 'GET'
         };
-        var responseString = '';
+        var responseData = '';
         cloudantClient.request(options)
           .on('error', function(err) {
             assert.fail(`Unexpected error: ${err}`);
@@ -1348,10 +1348,10 @@ describe('CloudantClient', function() {
             assert.equal(resp.statusCode, 200);
           })
           .on('data', function(data) {
-            responseString += data;
+            responseData += data;
           })
           .on('end', function() {
-            assert.ok(responseString.toString('utf8').indexOf('"ok":true') > -1);
+            assert.ok(responseData.toString('utf8').indexOf('"ok":true') > -1);
             assert.equal(cloudantClient._plugins[0].onResponseCallCount, 2);
             mocks.done();
             done();
@@ -1411,7 +1411,7 @@ describe('CloudantClient', function() {
           auth: { username: ME, password: PASSWORD },
           method: 'GET'
         };
-        var responseString = '';
+        var responseData = '';
         cloudantClient.request(options)
           .on('error', function(err) {
             assert.fail(`Unexpected error: ${err}`);
@@ -1420,10 +1420,10 @@ describe('CloudantClient', function() {
             assert.equal(resp.statusCode, 200);
           })
           .on('data', function(data) {
-            responseString += data;
+            responseData += data;
           })
           .on('end', function() {
-            assert.ok(responseString.toString('utf8').indexOf('"doc_count":1') > -1);
+            assert.ok(responseData.toString('utf8').indexOf('"doc_count":1') > -1);
             mocks.done();
             done();
           });

--- a/test/client.js
+++ b/test/client.js
@@ -954,6 +954,8 @@ describe('CloudantClient', function() {
           auth: { username: ME, password: PASSWORD },
           method: 'GET'
         };
+
+        var responseString = '';
         cloudantClient.request(options)
           .on('error', function(err) {
             assert.fail(`Unexpected error: ${err}`);
@@ -962,9 +964,10 @@ describe('CloudantClient', function() {
             assert.equal(resp.statusCode, 200);
           })
           .on('data', function(data) {
-            assert.ok(data.toString('utf8').indexOf('"doc_count":1') > -1);
+            responseString += data;
           })
           .on('end', function() {
+            assert.ok(responseString.toString('utf8').indexOf('"doc_count":1') > -1);
             mocks.done();
             done();
           });
@@ -1012,6 +1015,7 @@ describe('CloudantClient', function() {
           auth: { username: ME, password: PASSWORD },
           method: 'GET'
         };
+        var responseString = '';
         cloudantClient.request(options)
           .on('error', function(err) {
             assert.fail(`Unexpected error: ${err}`);
@@ -1020,9 +1024,10 @@ describe('CloudantClient', function() {
             assert.equal(resp.statusCode, 200);
           })
           .on('data', function(data) {
-            assert.ok(data.toString('utf8').indexOf('"doc_count":1') > -1);
+            responseString += data;
           })
           .on('end', function() {
+            assert.ok(responseString.toString('utf8').indexOf('"doc_count":1') > -1);
             assert.equal(cloudantClient._plugins[0].onRequestCallCount, 1);
             assert.equal(cloudantClient._plugins[0].onErrorCallCount, 0);
             assert.equal(cloudantClient._plugins[0].onResponseCallCount, 1);
@@ -1080,6 +1085,7 @@ describe('CloudantClient', function() {
           auth: { username: ME, password: PASSWORD },
           method: 'GET'
         };
+        var responseString = '';
         cloudantClient.request(options)
           .on('error', function(err) {
             assert.fail(`Unexpected error: ${err}`);
@@ -1088,9 +1094,10 @@ describe('CloudantClient', function() {
             assert.equal(resp.statusCode, 200);
           })
           .on('data', function(data) {
-            assert.ok(data.toString('utf8').indexOf('"doc_count":1') > -1);
+            responseString += data;
           })
           .on('end', function() {
+            assert.ok(responseString.toString('utf8').indexOf('"doc_count":1') > -1);
             assert.equal(cloudantClient._plugins[0].onRequestCallCount, 1);
             assert.equal(cloudantClient._plugins[0].onErrorCallCount, 0);
             assert.equal(cloudantClient._plugins[0].onResponseCallCount, 1);
@@ -1158,6 +1165,7 @@ describe('CloudantClient', function() {
           auth: { username: ME, password: PASSWORD },
           method: 'HEAD' // ComplexPlugin1 will set method to 'PUT'
         };
+        var responseString = '';
         var startTs = (new Date()).getTime();
         cloudantClient.request(options)
           .on('error', function(err) {
@@ -1168,9 +1176,10 @@ describe('CloudantClient', function() {
             assert.equal(resp.request.headers.ComplexPlugin1, 'foo');
           })
           .on('data', function(data) {
-            assert.ok(data.toString('utf8').indexOf('"error":"file_exists"') > -1);
+            responseString += data;
           })
           .on('end', function() {
+            assert.ok(responseString.toString('utf8').indexOf('"error":"file_exists"') > -1);
             assert.equal(cloudantClient._plugins[0].onRequestCallCount, 10);
             assert.equal(cloudantClient._plugins[0].onErrorCallCount, 0);
             assert.equal(cloudantClient._plugins[0].onResponseCallCount, 10);
@@ -1240,6 +1249,7 @@ describe('CloudantClient', function() {
           auth: { username: ME, password: PASSWORD },
           method: 'POST' // ComplexPlugin2 will set method to 'GET'
         };
+        var responseString = '';
         cloudantClient.request(options)
           .on('error', function(err) {
             assert.fail(`Unexpected error: ${err}`);
@@ -1249,9 +1259,10 @@ describe('CloudantClient', function() {
             assert.equal(resp.request.headers.ComplexPlugin2, 'bar');
           })
           .on('data', function(data) {
-            assert.ok(data.toString('utf8').indexOf('"error":"unauthorized"') > -1);
+            responseString += data;
           })
           .on('end', function() {
+            assert.ok(responseString.toString('utf8').indexOf('"error":"unauthorized"') > -1);
             assert.equal(cloudantClient._plugins[0].onRequestCallCount, 2);
             assert.equal(cloudantClient._plugins[0].onErrorCallCount, 0);
             assert.equal(cloudantClient._plugins[0].onResponseCallCount, 2);
@@ -1281,6 +1292,7 @@ describe('CloudantClient', function() {
           auth: { username: ME, password: PASSWORD },
           method: 'DELETE' // ComplexPlugin2 will set method to 'GET'
         };
+        var responseString = '';
         cloudantClient.request(options)
           .on('error', function(err) {
             assert.fail(`Unexpected error: ${err}`);
@@ -1289,9 +1301,10 @@ describe('CloudantClient', function() {
             assert.equal(resp.statusCode, 200);
           })
           .on('data', function(data) {
-            assert.ok(data.toString('utf8').indexOf('"ok":true') > -1);
+            responseString += data;
           })
           .on('end', function() {
+            assert.ok(responseString.toString('utf8').indexOf('"ok":true') > -1);
             assert.equal(cloudantClient._plugins[0].onRequestCallCount, 1);
             assert.equal(cloudantClient._plugins[0].onErrorCallCount, 1);
             assert.equal(cloudantClient._plugins[0].onResponseCallCount, 0);
@@ -1326,6 +1339,7 @@ describe('CloudantClient', function() {
           auth: { username: ME, password: PASSWORD },
           method: 'GET'
         };
+        var responseString = '';
         cloudantClient.request(options)
           .on('error', function(err) {
             assert.fail(`Unexpected error: ${err}`);
@@ -1334,9 +1348,10 @@ describe('CloudantClient', function() {
             assert.equal(resp.statusCode, 200);
           })
           .on('data', function(data) {
-            assert.ok(data.toString('utf8').indexOf('"ok":true') > -1);
+            responseString += data;
           })
           .on('end', function() {
+            assert.ok(responseString.toString('utf8').indexOf('"ok":true') > -1);
             assert.equal(cloudantClient._plugins[0].onResponseCallCount, 2);
             mocks.done();
             done();
@@ -1396,6 +1411,7 @@ describe('CloudantClient', function() {
           auth: { username: ME, password: PASSWORD },
           method: 'GET'
         };
+        var responseString = '';
         cloudantClient.request(options)
           .on('error', function(err) {
             assert.fail(`Unexpected error: ${err}`);
@@ -1404,9 +1420,10 @@ describe('CloudantClient', function() {
             assert.equal(resp.statusCode, 200);
           })
           .on('data', function(data) {
-            assert.ok(data.toString('utf8').indexOf('"doc_count":1') > -1);
+            responseString += data;
           })
           .on('end', function() {
+            assert.ok(responseString.toString('utf8').indexOf('"doc_count":1') > -1);
             mocks.done();
             done();
           });

--- a/test/plugins/retry.js
+++ b/test/plugins/retry.js
@@ -279,7 +279,7 @@ describe('Retry Plugin', function() {
 
         var dataFile = fs.createWriteStream('data.json');
 
-        var responseString = '';
+        var responseData = '';
 
         cloudantClient.request(req)
           .on('error', function(err) {
@@ -290,10 +290,10 @@ describe('Retry Plugin', function() {
             assert.equal(resp.statusCode, 200);
           })
           .on('data', function(data) {
-            responseString += data;
+            responseData += data;
           })
           .on('end', function() {
-            assert.ok(responseString.toString('utf8').indexOf('"doc_count":0') > -1);
+            assert.ok(responseData.toString('utf8').indexOf('"doc_count":0') > -1);
             assert.equal(responseCount, 1);
           })
           .pipe(dataFile)
@@ -364,7 +364,7 @@ describe('Retry Plugin', function() {
 
         var startTs = (new Date()).getTime();
 
-        var responseString = '';
+        var responseData = '';
         cloudantClient.request(req)
           .on('error', function(err) {
             assert.fail(`Unexpected error: ${err}`);
@@ -374,10 +374,10 @@ describe('Retry Plugin', function() {
             assert.equal(resp.statusCode, 200);
           })
           .on('data', function(data) {
-            responseString += data;
+            responseData += data;
           })
           .on('end', function() {
-            assert.ok(responseString.toString('utf8').indexOf('"doc_count":0') > -1);
+            assert.ok(responseData.toString('utf8').indexOf('"doc_count":0') > -1);
             assert.equal(responseCount, 1);
 
             // validate retry delay
@@ -456,7 +456,7 @@ describe('Retry Plugin', function() {
 
         var startTs = (new Date()).getTime();
 
-        var responseString = '';
+        var responseData = '';
         cloudantClient.request(req)
           .on('error', function(err) {
             assert.fail(`Unexpected error: ${err}`);
@@ -466,10 +466,10 @@ describe('Retry Plugin', function() {
             assert.equal(resp.statusCode, 500);
           })
           .on('data', function(data) {
-            responseString += data;
+            responseData += data;
           })
           .on('end', function() {
-            assert.ok(responseString.toString('utf8').indexOf('"error":"internal_server_error"') > -1);
+            assert.ok(responseData.toString('utf8').indexOf('"error":"internal_server_error"') > -1);
             assert.equal(responseCount, 1);
 
             // validate retry delay
@@ -515,7 +515,7 @@ describe('Retry Plugin', function() {
 
         var startTs = (new Date()).getTime();
 
-        var responseString = '';
+        var responseData = '';
         readable.pipe(cloudantClient.request(req))
           .on('error', function(err) {
             assert.fail(`Unexpected error: ${err}`);
@@ -525,10 +525,10 @@ describe('Retry Plugin', function() {
             assert.equal(resp.statusCode, 200);
           })
           .on('data', function(data) {
-            responseString += data;
+            responseData += data;
           })
           .on('end', function() {
-            assert.ok(responseString.toString('utf8').indexOf('"key":"doc1","value":{"rev":"1') > -1);
+            assert.ok(responseData.toString('utf8').indexOf('"key":"doc1","value":{"rev":"1') > -1);
             assert.equal(responseCount, 1);
 
             // validate retry delay
@@ -567,7 +567,7 @@ describe('Retry Plugin', function() {
 
         var dataFile = fs.createWriteStream('data.json');
 
-        var responseString = '';
+        var responseData = '';
         cloudantClient.request(req, function(err, resp, data) {
           assert.equal(err, null);
           assert.equal(resp.statusCode, 200);
@@ -581,10 +581,10 @@ describe('Retry Plugin', function() {
             assert.equal(resp.statusCode, 200);
           })
           .on('data', function(data) {
-            responseString += data;
+            responseData += data;
           })
           .on('end', function() {
-            assert.ok(responseString.toString('utf8').indexOf('"doc_count":0') > -1);
+            assert.ok(responseData.toString('utf8').indexOf('"doc_count":0') > -1);
             assert.equal(responseCount, 1);
           })
           .pipe(dataFile)
@@ -658,7 +658,7 @@ describe('Retry Plugin', function() {
 
         var startTs = (new Date()).getTime();
 
-        var responseString = '';
+        var responseData = '';
         cloudantClient.request(req, function(err, resp, data) {
           assert.equal(err, null);
           assert.equal(resp.statusCode, 200);
@@ -672,10 +672,10 @@ describe('Retry Plugin', function() {
             assert.equal(resp.statusCode, 200);
           })
           .on('data', function(data) {
-            responseString += data;
+            responseData += data;
           })
           .on('end', function() {
-            assert.ok(responseString.toString('utf8').indexOf('"doc_count":0') > -1);
+            assert.ok(responseData.toString('utf8').indexOf('"doc_count":0') > -1);
             assert.equal(responseCount, 1);
 
             // validate retry delay
@@ -757,7 +757,7 @@ describe('Retry Plugin', function() {
 
         var startTs = (new Date()).getTime();
 
-        var responseString = '';
+        var responseData = '';
         cloudantClient.request(req, function(err, resp, data) {
           assert.equal(err, null);
           assert.equal(resp.statusCode, 500);
@@ -771,10 +771,10 @@ describe('Retry Plugin', function() {
             assert.equal(resp.statusCode, 500);
           })
           .on('data', function(data) {
-            responseString += data;
+            responseData += data;
           })
           .on('end', function() {
-            assert.ok(responseString.toString('utf8').indexOf('"error":"internal_server_error"') > -1);
+            assert.ok(responseData.toString('utf8').indexOf('"error":"internal_server_error"') > -1);
             assert.equal(responseCount, 1);
 
             // validate retry delay
@@ -820,7 +820,7 @@ describe('Retry Plugin', function() {
 
         var startTs = (new Date()).getTime();
 
-        var responseString = '';
+        var responseData = '';
         readable.pipe(cloudantClient.request(req, function(err, resp, data) {
           assert.equal(err, null);
           assert.equal(resp.statusCode, 200);
@@ -834,10 +834,10 @@ describe('Retry Plugin', function() {
             assert.equal(resp.statusCode, 200);
           })
           .on('data', function(data) {
-            responseString += data;
+            responseData += data;
           })
           .on('end', function() {
-            assert.ok(responseString.toString('utf8').indexOf('"key":"doc1","value":{"rev":"1') > -1);
+            assert.ok(responseData.toString('utf8').indexOf('"key":"doc1","value":{"rev":"1') > -1);
             assert.equal(responseCount, 1);
 
             // validate retry delay
@@ -965,7 +965,7 @@ describe('Retry Plugin', function() {
 
         var dataFile = fs.createWriteStream('data.json');
 
-        var responseString = '';
+        var responseData = '';
         cloudantClient.request(req)
           .on('error', function(err) {
             assert.fail(`Unexpected error: ${err}`);
@@ -975,10 +975,10 @@ describe('Retry Plugin', function() {
             assert.equal(resp.statusCode, 200);
           })
           .on('data', function(data) {
-            responseString += data;
+            responseData += data;
           })
           .on('end', function() {
-            assert.ok(responseString.toString('utf8').indexOf('"doc_count":0') > -1);
+            assert.ok(responseData.toString('utf8').indexOf('"doc_count":0') > -1);
             assert.equal(responseCount, 1);
           })
           .pipe(dataFile)
@@ -1016,7 +1016,7 @@ describe('Retry Plugin', function() {
 
         var startTs = (new Date()).getTime();
 
-        var responseString = '';
+        var responseData = '';
         cloudantClient.request(req)
           .on('error', function(err) {
             assert.fail(`Unexpected error: ${err}`);
@@ -1026,10 +1026,10 @@ describe('Retry Plugin', function() {
             assert.equal(resp.statusCode, 200);
           })
           .on('data', function(data) {
-            responseString += data;
+            responseData += data;
           })
           .on('end', function() {
-            assert.ok(responseString.toString('utf8').indexOf('"doc_count":0') > -1);
+            assert.ok(responseData.toString('utf8').indexOf('"doc_count":0') > -1);
             assert.equal(responseCount, 1);
 
             // validate retry delay
@@ -1104,7 +1104,7 @@ describe('Retry Plugin', function() {
 
         var dataFile = fs.createWriteStream('data.json');
 
-        var responseString = '';
+        var responseData = '';
         cloudantClient.request(req, function(err, resp, data) {
           assert.equal(err, null);
           assert.equal(resp.statusCode, 200);
@@ -1118,10 +1118,10 @@ describe('Retry Plugin', function() {
             assert.equal(resp.statusCode, 200);
           })
           .on('data', function(data) {
-            responseString += data;
+            responseData += data;
           })
           .on('end', function() {
-            assert.ok(responseString.toString('utf8').indexOf('"doc_count":0') > -1);
+            assert.ok(responseData.toString('utf8').indexOf('"doc_count":0') > -1);
             assert.equal(responseCount, 1);
           })
           .pipe(dataFile)
@@ -1160,7 +1160,7 @@ describe('Retry Plugin', function() {
 
         var startTs = (new Date()).getTime();
 
-        var responseString = '';
+        var responseData = '';
         cloudantClient.request(req, function(err, resp, data) {
           assert.equal(err, null);
           assert.equal(resp.statusCode, 200);
@@ -1174,10 +1174,10 @@ describe('Retry Plugin', function() {
             assert.equal(resp.statusCode, 200);
           })
           .on('data', function(data) {
-            responseString += data;
+            responseData += data;
           })
           .on('end', function() {
-            assert.ok(responseString.toString('utf8').indexOf('"doc_count":0') > -1);
+            assert.ok(responseData.toString('utf8').indexOf('"doc_count":0') > -1);
             assert.equal(responseCount, 1);
 
             // validate retry delay

--- a/test/plugins/retry.js
+++ b/test/plugins/retry.js
@@ -275,7 +275,6 @@ describe('Retry Plugin', function() {
           method: 'GET'
         };
 
-        var dataCount = 0;
         var responseCount = 0;
 
         var dataFile = fs.createWriteStream('data.json');
@@ -291,13 +290,11 @@ describe('Retry Plugin', function() {
             assert.equal(resp.statusCode, 200);
           })
           .on('data', function(data) {
-            dataCount++;
             responseString += data;
           })
           .on('end', function() {
             assert.ok(responseString.toString('utf8').indexOf('"doc_count":0') > -1);
             assert.equal(responseCount, 1);
-            assert.equal(dataCount, 1);
           })
           .pipe(dataFile)
           .on('finish', function() {
@@ -361,8 +358,6 @@ describe('Retry Plugin', function() {
           auth: { username: ME, password: PASSWORD },
           method: 'GET'
         };
-
-        var dataCount = 0;
         var responseCount = 0;
 
         var dataFile = fs.createWriteStream('data.json');
@@ -379,13 +374,11 @@ describe('Retry Plugin', function() {
             assert.equal(resp.statusCode, 200);
           })
           .on('data', function(data) {
-            dataCount++;
             responseString += data;
           })
           .on('end', function() {
             assert.ok(responseString.toString('utf8').indexOf('"doc_count":0') > -1);
             assert.equal(responseCount, 1);
-            assert.equal(dataCount, 1);
 
             // validate retry delay
             var now = (new Date()).getTime();
@@ -459,8 +452,6 @@ describe('Retry Plugin', function() {
           auth: { username: ME, password: PASSWORD },
           method: 'GET'
         };
-
-        var dataCount = 0;
         var responseCount = 0;
 
         var startTs = (new Date()).getTime();
@@ -475,13 +466,11 @@ describe('Retry Plugin', function() {
             assert.equal(resp.statusCode, 500);
           })
           .on('data', function(data) {
-            dataCount++;
             responseString += data;
           })
           .on('end', function() {
             assert.ok(responseString.toString('utf8').indexOf('"error":"internal_server_error"') > -1);
             assert.equal(responseCount, 1);
-            assert.equal(dataCount, 1);
 
             // validate retry delay
             var now = (new Date()).getTime();
@@ -516,8 +505,6 @@ describe('Retry Plugin', function() {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' }
         };
-
-        var dataCount = 0;
         var responseCount = 0;
 
         var dataFile = fs.createWriteStream('data.json');
@@ -538,13 +525,11 @@ describe('Retry Plugin', function() {
             assert.equal(resp.statusCode, 200);
           })
           .on('data', function(data) {
-            dataCount++;
             responseString += data;
           })
           .on('end', function() {
             assert.ok(responseString.toString('utf8').indexOf('"key":"doc1","value":{"rev":"1') > -1);
             assert.equal(responseCount, 1);
-            assert.equal(dataCount, 1);
 
             // validate retry delay
             var now = (new Date()).getTime();
@@ -578,7 +563,6 @@ describe('Retry Plugin', function() {
           method: 'GET'
         };
 
-        var dataCount = 0;
         var responseCount = 0;
 
         var dataFile = fs.createWriteStream('data.json');
@@ -597,13 +581,11 @@ describe('Retry Plugin', function() {
             assert.equal(resp.statusCode, 200);
           })
           .on('data', function(data) {
-            dataCount++;
             responseString += data;
           })
           .on('end', function() {
             assert.ok(responseString.toString('utf8').indexOf('"doc_count":0') > -1);
             assert.equal(responseCount, 1);
-            assert.equal(dataCount, 1);
           })
           .pipe(dataFile)
           .on('finish', function() {
@@ -670,8 +652,6 @@ describe('Retry Plugin', function() {
           auth: { username: ME, password: PASSWORD },
           method: 'GET'
         };
-
-        var dataCount = 0;
         var responseCount = 0;
 
         var dataFile = fs.createWriteStream('data.json');
@@ -692,13 +672,11 @@ describe('Retry Plugin', function() {
             assert.equal(resp.statusCode, 200);
           })
           .on('data', function(data) {
-            dataCount++;
             responseString += data;
           })
           .on('end', function() {
             assert.ok(responseString.toString('utf8').indexOf('"doc_count":0') > -1);
             assert.equal(responseCount, 1);
-            assert.equal(dataCount, 1);
 
             // validate retry delay
             var now = (new Date()).getTime();
@@ -775,8 +753,6 @@ describe('Retry Plugin', function() {
           auth: { username: ME, password: PASSWORD },
           method: 'GET'
         };
-
-        var dataCount = 0;
         var responseCount = 0;
 
         var startTs = (new Date()).getTime();
@@ -795,13 +771,11 @@ describe('Retry Plugin', function() {
             assert.equal(resp.statusCode, 500);
           })
           .on('data', function(data) {
-            dataCount++;
             responseString += data;
           })
           .on('end', function() {
             assert.ok(responseString.toString('utf8').indexOf('"error":"internal_server_error"') > -1);
             assert.equal(responseCount, 1);
-            assert.equal(dataCount, 1);
 
             // validate retry delay
             var now = (new Date()).getTime();
@@ -836,8 +810,6 @@ describe('Retry Plugin', function() {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' }
         };
-
-        var dataCount = 0;
         var responseCount = 0;
 
         var dataFile = fs.createWriteStream('data.json');
@@ -862,13 +834,11 @@ describe('Retry Plugin', function() {
             assert.equal(resp.statusCode, 200);
           })
           .on('data', function(data) {
-            dataCount++;
             responseString += data;
           })
           .on('end', function() {
             assert.ok(responseString.toString('utf8').indexOf('"key":"doc1","value":{"rev":"1') > -1);
             assert.equal(responseCount, 1);
-            assert.equal(dataCount, 1);
 
             // validate retry delay
             var now = (new Date()).getTime();
@@ -991,7 +961,6 @@ describe('Retry Plugin', function() {
           method: 'GET'
         };
 
-        var dataCount = 0;
         var responseCount = 0;
 
         var dataFile = fs.createWriteStream('data.json');
@@ -1006,13 +975,11 @@ describe('Retry Plugin', function() {
             assert.equal(resp.statusCode, 200);
           })
           .on('data', function(data) {
-            dataCount++;
             responseString += data;
           })
           .on('end', function() {
             assert.ok(responseString.toString('utf8').indexOf('"doc_count":0') > -1);
             assert.equal(responseCount, 1);
-            assert.equal(dataCount, 1);
           })
           .pipe(dataFile)
           .on('finish', function() {
@@ -1043,8 +1010,6 @@ describe('Retry Plugin', function() {
           auth: { username: ME, password: PASSWORD },
           method: 'GET'
         };
-
-        var dataCount = 0;
         var responseCount = 0;
 
         var dataFile = fs.createWriteStream('data.json');
@@ -1061,13 +1026,11 @@ describe('Retry Plugin', function() {
             assert.equal(resp.statusCode, 200);
           })
           .on('data', function(data) {
-            dataCount++;
             responseString += data;
           })
           .on('end', function() {
             assert.ok(responseString.toString('utf8').indexOf('"doc_count":0') > -1);
             assert.equal(responseCount, 1);
-            assert.equal(dataCount, 1);
 
             // validate retry delay
             var now = (new Date()).getTime();
@@ -1137,7 +1100,6 @@ describe('Retry Plugin', function() {
           method: 'GET'
         };
 
-        var dataCount = 0;
         var responseCount = 0;
 
         var dataFile = fs.createWriteStream('data.json');
@@ -1156,13 +1118,11 @@ describe('Retry Plugin', function() {
             assert.equal(resp.statusCode, 200);
           })
           .on('data', function(data) {
-            dataCount++;
             responseString += data;
           })
           .on('end', function() {
             assert.ok(responseString.toString('utf8').indexOf('"doc_count":0') > -1);
             assert.equal(responseCount, 1);
-            assert.equal(dataCount, 1);
           })
           .pipe(dataFile)
           .on('finish', function() {
@@ -1194,7 +1154,6 @@ describe('Retry Plugin', function() {
           method: 'GET'
         };
 
-        var dataCount = 0;
         var responseCount = 0;
 
         var dataFile = fs.createWriteStream('data.json');
@@ -1215,13 +1174,11 @@ describe('Retry Plugin', function() {
             assert.equal(resp.statusCode, 200);
           })
           .on('data', function(data) {
-            dataCount++;
             responseString += data;
           })
           .on('end', function() {
             assert.ok(responseString.toString('utf8').indexOf('"doc_count":0') > -1);
             assert.equal(responseCount, 1);
-            assert.equal(dataCount, 1);
 
             // validate retry delay
             var now = (new Date()).getTime();

--- a/test/plugins/retry.js
+++ b/test/plugins/retry.js
@@ -280,6 +280,8 @@ describe('Retry Plugin', function() {
 
         var dataFile = fs.createWriteStream('data.json');
 
+        var responseString = '';
+
         cloudantClient.request(req)
           .on('error', function(err) {
             assert.fail(`Unexpected error: ${err}`);
@@ -290,9 +292,10 @@ describe('Retry Plugin', function() {
           })
           .on('data', function(data) {
             dataCount++;
-            assert.ok(data.toString('utf8').indexOf('"doc_count":0') > -1);
+            responseString += data;
           })
           .on('end', function() {
+            assert.ok(responseString.toString('utf8').indexOf('"doc_count":0') > -1);
             assert.equal(responseCount, 1);
             assert.equal(dataCount, 1);
           })
@@ -365,6 +368,8 @@ describe('Retry Plugin', function() {
         var dataFile = fs.createWriteStream('data.json');
 
         var startTs = (new Date()).getTime();
+
+        var responseString = '';
         cloudantClient.request(req)
           .on('error', function(err) {
             assert.fail(`Unexpected error: ${err}`);
@@ -375,9 +380,10 @@ describe('Retry Plugin', function() {
           })
           .on('data', function(data) {
             dataCount++;
-            assert.ok(data.toString('utf8').indexOf('"doc_count":0') > -1);
+            responseString += data;
           })
           .on('end', function() {
+            assert.ok(responseString.toString('utf8').indexOf('"doc_count":0') > -1);
             assert.equal(responseCount, 1);
             assert.equal(dataCount, 1);
 
@@ -458,6 +464,8 @@ describe('Retry Plugin', function() {
         var responseCount = 0;
 
         var startTs = (new Date()).getTime();
+
+        var responseString = '';
         cloudantClient.request(req)
           .on('error', function(err) {
             assert.fail(`Unexpected error: ${err}`);
@@ -468,9 +476,10 @@ describe('Retry Plugin', function() {
           })
           .on('data', function(data) {
             dataCount++;
-            assert.ok(data.toString('utf8').indexOf('"error":"internal_server_error"') > -1);
+            responseString += data;
           })
           .on('end', function() {
+            assert.ok(responseString.toString('utf8').indexOf('"error":"internal_server_error"') > -1);
             assert.equal(responseCount, 1);
             assert.equal(dataCount, 1);
 
@@ -518,6 +527,8 @@ describe('Retry Plugin', function() {
         readable.push(null);
 
         var startTs = (new Date()).getTime();
+
+        var responseString = '';
         readable.pipe(cloudantClient.request(req))
           .on('error', function(err) {
             assert.fail(`Unexpected error: ${err}`);
@@ -528,9 +539,10 @@ describe('Retry Plugin', function() {
           })
           .on('data', function(data) {
             dataCount++;
-            assert.ok(data.indexOf('"key":"doc1","value":{"rev":"1') > -1);
+            responseString += data;
           })
           .on('end', function() {
+            assert.ok(responseString.toString('utf8').indexOf('"key":"doc1","value":{"rev":"1') > -1);
             assert.equal(responseCount, 1);
             assert.equal(dataCount, 1);
 
@@ -571,6 +583,7 @@ describe('Retry Plugin', function() {
 
         var dataFile = fs.createWriteStream('data.json');
 
+        var responseString = '';
         cloudantClient.request(req, function(err, resp, data) {
           assert.equal(err, null);
           assert.equal(resp.statusCode, 200);
@@ -585,9 +598,10 @@ describe('Retry Plugin', function() {
           })
           .on('data', function(data) {
             dataCount++;
-            assert.ok(data.toString('utf8').indexOf('"doc_count":0') > -1);
+            responseString += data;
           })
           .on('end', function() {
+            assert.ok(responseString.toString('utf8').indexOf('"doc_count":0') > -1);
             assert.equal(responseCount, 1);
             assert.equal(dataCount, 1);
           })
@@ -663,6 +677,8 @@ describe('Retry Plugin', function() {
         var dataFile = fs.createWriteStream('data.json');
 
         var startTs = (new Date()).getTime();
+
+        var responseString = '';
         cloudantClient.request(req, function(err, resp, data) {
           assert.equal(err, null);
           assert.equal(resp.statusCode, 200);
@@ -677,9 +693,10 @@ describe('Retry Plugin', function() {
           })
           .on('data', function(data) {
             dataCount++;
-            assert.ok(data.toString('utf8').indexOf('"doc_count":0') > -1);
+            responseString += data;
           })
           .on('end', function() {
+            assert.ok(responseString.toString('utf8').indexOf('"doc_count":0') > -1);
             assert.equal(responseCount, 1);
             assert.equal(dataCount, 1);
 
@@ -763,6 +780,8 @@ describe('Retry Plugin', function() {
         var responseCount = 0;
 
         var startTs = (new Date()).getTime();
+
+        var responseString = '';
         cloudantClient.request(req, function(err, resp, data) {
           assert.equal(err, null);
           assert.equal(resp.statusCode, 500);
@@ -777,9 +796,10 @@ describe('Retry Plugin', function() {
           })
           .on('data', function(data) {
             dataCount++;
-            assert.ok(data.toString('utf8').indexOf('"error":"internal_server_error"') > -1);
+            responseString += data;
           })
           .on('end', function() {
+            assert.ok(responseString.toString('utf8').indexOf('"error":"internal_server_error"') > -1);
             assert.equal(responseCount, 1);
             assert.equal(dataCount, 1);
 
@@ -827,6 +847,8 @@ describe('Retry Plugin', function() {
         readable.push(null);
 
         var startTs = (new Date()).getTime();
+
+        var responseString = '';
         readable.pipe(cloudantClient.request(req, function(err, resp, data) {
           assert.equal(err, null);
           assert.equal(resp.statusCode, 200);
@@ -841,9 +863,10 @@ describe('Retry Plugin', function() {
           })
           .on('data', function(data) {
             dataCount++;
-            assert.ok(data.indexOf('"key":"doc1","value":{"rev":"1') > -1);
+            responseString += data;
           })
           .on('end', function() {
+            assert.ok(responseString.toString('utf8').indexOf('"key":"doc1","value":{"rev":"1') > -1);
             assert.equal(responseCount, 1);
             assert.equal(dataCount, 1);
 
@@ -973,6 +996,7 @@ describe('Retry Plugin', function() {
 
         var dataFile = fs.createWriteStream('data.json');
 
+        var responseString = '';
         cloudantClient.request(req)
           .on('error', function(err) {
             assert.fail(`Unexpected error: ${err}`);
@@ -983,9 +1007,10 @@ describe('Retry Plugin', function() {
           })
           .on('data', function(data) {
             dataCount++;
-            assert.ok(data.toString('utf8').indexOf('"doc_count":0') > -1);
+            responseString += data;
           })
           .on('end', function() {
+            assert.ok(responseString.toString('utf8').indexOf('"doc_count":0') > -1);
             assert.equal(responseCount, 1);
             assert.equal(dataCount, 1);
           })
@@ -1025,6 +1050,8 @@ describe('Retry Plugin', function() {
         var dataFile = fs.createWriteStream('data.json');
 
         var startTs = (new Date()).getTime();
+
+        var responseString = '';
         cloudantClient.request(req)
           .on('error', function(err) {
             assert.fail(`Unexpected error: ${err}`);
@@ -1035,9 +1062,10 @@ describe('Retry Plugin', function() {
           })
           .on('data', function(data) {
             dataCount++;
-            assert.ok(data.toString('utf8').indexOf('"doc_count":0') > -1);
+            responseString += data;
           })
           .on('end', function() {
+            assert.ok(responseString.toString('utf8').indexOf('"doc_count":0') > -1);
             assert.equal(responseCount, 1);
             assert.equal(dataCount, 1);
 
@@ -1114,6 +1142,7 @@ describe('Retry Plugin', function() {
 
         var dataFile = fs.createWriteStream('data.json');
 
+        var responseString = '';
         cloudantClient.request(req, function(err, resp, data) {
           assert.equal(err, null);
           assert.equal(resp.statusCode, 200);
@@ -1128,9 +1157,10 @@ describe('Retry Plugin', function() {
           })
           .on('data', function(data) {
             dataCount++;
-            assert.ok(data.toString('utf8').indexOf('"doc_count":0') > -1);
+            responseString += data;
           })
           .on('end', function() {
+            assert.ok(responseString.toString('utf8').indexOf('"doc_count":0') > -1);
             assert.equal(responseCount, 1);
             assert.equal(dataCount, 1);
           })
@@ -1170,6 +1200,8 @@ describe('Retry Plugin', function() {
         var dataFile = fs.createWriteStream('data.json');
 
         var startTs = (new Date()).getTime();
+
+        var responseString = '';
         cloudantClient.request(req, function(err, resp, data) {
           assert.equal(err, null);
           assert.equal(resp.statusCode, 200);
@@ -1184,9 +1216,10 @@ describe('Retry Plugin', function() {
           })
           .on('data', function(data) {
             dataCount++;
-            assert.ok(data.toString('utf8').indexOf('"doc_count":0') > -1);
+            responseString += data;
           })
           .on('end', function() {
+            assert.ok(responseString.toString('utf8').indexOf('"doc_count":0') > -1);
             assert.equal(responseCount, 1);
             assert.equal(dataCount, 1);
 


### PR DESCRIPTION
<!--
Thanks for your hard work, please ensure all items are complete before opening.
-->
## Checklist

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)
- [x] Added tests for code changes _or_ test/build only changes
- [x] Updated the change log file (`CHANGES.md`|`CHANGELOG.md`) _or_ test/build only changes
- [x] Completed the PR template below:

## Description
Some of the tests assert on streaming response data in the `data` callback.  This can cause a failure since the assertion will fail in a case where there's more than one chunk of streaming data.  This PR concatenates the streaming data then asserts once the stream is completed in `end` block.
<!--
Provide a short description; saving the detail for the `Approach` section

Also EITHER:
Link to issue this PR is resolving, use the Fixes #nnn form so that the
issue closes automatically when the PR merges e.g.:

Fixes #23

OR

For PRs without an associated issue and/or test/build issues

### 1. Steps to reproduce and the simplest code sample possible to demonstrate the issue
### 2. What you expected to happen
### 3. What actually happened
-->

## Approach
- Create a `responseString` variable to hold the streaming data and then assert on this variable once the stream is complete
- Removed failing and redundant data chunk count assertion.  We are already asserting on the streaming data
<!--
Be brief: which component(s) of the code base does the fix focus on.

A place to note whether the part of the code base that is being worked is
particularly sensitive.
-->

## Schema & API Changes

<!--
EITHER:

- "No change"

OR

For public API (as opposed to internal) changes

- "Fixing bug in API, will change x in such-and-such way"
-->

## Security and Privacy

<!--
EITHER:

- "No change"

OR

"Making changes in e.g. auth|https|encryption|io
need to be careful about..."

-->

## Testing

<!--
EITHER:

- Added new tests:
    - test x
    - test y
    - test z

OR

- Modified existing tests because ...

OR

- N/A build or packaging only changes

OR

In exceptional circumstances there may be a good reason we can't add automated
tests, for example if a specific device is required to reproduce a problem.

- No new tests because...
-->

## Monitoring and Logging
<!--
EITHER:

- "No change"

OR

- "Added new log line X..."
-->
