### PR TITLE
Add cache support for IAM token

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+# 4.3.0 (2020-07-16)
+- [NEW] Added support for a cache to be optionally used in conjunction with the
+  iamauth plugin, in order to store and retrieve an IAM auth token and lower 
+  the number of IAM token exchanges.
+- [UPGRADED] Upgraded lodash to 4.17.19
+
 # 4.2.4 (2020-03-02)
 - [FIXED] Pinned Nano to version 8.1 to resolve issue with extending upstream
   TypeScript changes in Nano version 8.2.0.

--- a/lib/tokens/IamTokenManager.js
+++ b/lib/tokens/IamTokenManager.js
@@ -59,7 +59,7 @@ class IAMTokenManager extends TokenManager {
             'apikey': self._iamApiKey
           },
           json: true
-        }, (error, response, body) => {
+        }, async(error, response, body) => {
           if (error) {
             callback(error);
           } else if (response.statusCode === 200) {

--- a/lib/tokens/IamTokenManager.js
+++ b/lib/tokens/IamTokenManager.js
@@ -17,6 +17,8 @@ const a = require('async');
 const debug = require('debug')('cloudant:tokens:iamtokenmanager');
 const TokenManager = require('./TokenManager');
 
+const CACHE_KEY = 'cloudant_iam_access_token';
+
 class IAMTokenManager extends TokenManager {
   constructor(client, jar, sessionUrl, iamTokenUrl, iamApiKey, iamClientId, iamClientSecret, cache, cacheOffsetInSecs) {
     super(client, jar, sessionUrl);
@@ -36,7 +38,7 @@ class IAMTokenManager extends TokenManager {
     let accessToken;
 
     if (this._cache) {
-      accessToken = await this._cache.get('cloudant_iam_access_token');
+      accessToken = await this._cache.get(CACHE_KEY);
       if (accessToken) debug('Using cached access token');
     }
 
@@ -67,7 +69,7 @@ class IAMTokenManager extends TokenManager {
               accessToken = body.access_token;
               if (this._cache) {
                 const ttl = this._cacheOffsetInSecs && body.expires_in > this._cacheOffsetInSecs ? body.expires_in - this._cacheOffsetInSecs : body.expires_in;
-                await this._cache.set('cloudant_iam_access_token', body.access_token, ttl);
+                await this._cache.set(CACHE_KEY, body.access_token, ttl);
               }
               debug('Retrieved access token from IAM token service.');
               callback(null, response);

--- a/lib/tokens/IamTokenManager.js
+++ b/lib/tokens/IamTokenManager.js
@@ -37,6 +37,7 @@ class IAMTokenManager extends TokenManager {
 
     if (this._cache) {
       accessToken = await this._cache.get('cloudant_iam_access_token');
+      if (accessToken) debug('Using cached access token');
     }
 
     a.series([

--- a/lib/tokens/IamTokenManager.js
+++ b/lib/tokens/IamTokenManager.js
@@ -1,4 +1,4 @@
-// Copyright © 2019 IBM Corp. All rights reserved.
+// Copyright © 2019, 2020 IBM Corp. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,22 +18,30 @@ const debug = require('debug')('cloudant:tokens:iamtokenmanager');
 const TokenManager = require('./TokenManager');
 
 class IAMTokenManager extends TokenManager {
-  constructor(client, jar, sessionUrl, iamTokenUrl, iamApiKey, iamClientId, iamClientSecret) {
+  constructor(client, jar, sessionUrl, iamTokenUrl, iamApiKey, iamClientId, iamClientSecret, cache, cacheOffsetInSecs) {
     super(client, jar, sessionUrl);
 
     this._iamTokenUrl = iamTokenUrl;
     this._iamApiKey = iamApiKey;
     this._iamClientId = iamClientId;
     this._iamClientSecret = iamClientSecret;
+    this._cache = cache;
+    this._cacheOffsetInSecs = cacheOffsetInSecs;
   }
 
-  _getToken(done) {
+  async _getToken(done) {
     var self = this;
 
     debug('Making IAM session request.');
     let accessToken;
+
+    if (this._cache) {
+      accessToken = await this._cache.get('cloudant_iam_access_token');
+    }
+
     a.series([
       (callback) => {
+        if (accessToken) return callback(); // use cached token.
         let accessTokenAuth;
         if (self._iamClientId && self._iamClientSecret) {
           accessTokenAuth = { user: self._iamClientId, pass: self._iamClientSecret };
@@ -56,6 +64,10 @@ class IAMTokenManager extends TokenManager {
           } else if (response.statusCode === 200) {
             if (body.access_token) {
               accessToken = body.access_token;
+              if (this._cache) {
+                const ttl = this._cacheOffsetInSecs && body.expires_in > this._cacheOffsetInSecs ? body.expires_in - this._cacheOffsetInSecs : body.expires_in;
+                await this._cache.set('cloudant_iam_access_token', body.access_token, ttl);
+              }
               debug('Retrieved access token from IAM token service.');
               callback(null, response);
             } else {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1553,9 +1553,9 @@
       "integrity": "sha1-Jjj8OaAzHpysGgS3F5mTHJxQ33k="
     },
     "lodash": {
-      "version": "4.17.15",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+      "version": "4.17.19",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
     },
     "log-symbols": {
       "version": "3.0.0",

--- a/plugins/iamauth.js
+++ b/plugins/iamauth.js
@@ -1,4 +1,4 @@
-// Copyright © 2017, 2019 IBM Corp. All rights reserved.
+// Copyright © 2017, 2020 IBM Corp. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -49,7 +49,9 @@ class IAMPlugin extends BasePlugin {
       cfg.iamTokenUrl,
       cfg.iamApiKey,
       cfg.iamClientId,
-      cfg.iamClientSecret
+      cfg.iamClientSecret,
+      cfg.cache,
+      cfg.cacheOffsetInSecs
     );
 
     if (cfg.autoRenew) {


### PR DESCRIPTION
## Checklist

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)
- [x] Added tests for code changes _or_ test/build only changes
- [x] Updated the change log file (`CHANGES.md`|`CHANGELOG.md`) _or_ test/build only changes
- [x] Completed the PR template below:

## Description
<!--
Provide a short description; saving the detail for the `Approach` section

Also EITHER:
Link to issue this PR is resolving, use the Fixes #nnn form so that the
issue closes automatically when the PR merges e.g.:

Fixes #23

OR

For PRs without an associated issue and/or test/build issues

### 1. Steps to reproduce and the simplest code sample possible to demonstrate the issue
### 2. What you expected to happen
### 3. What actually happened
-->
The problem this PR is trying to address is the issue of excessive IAM API key exchanges for access tokens. We share the IAM API key to interact with our cloudant account with all squads in our tribe and we were hitting the rate limit that IAM had set for API key exchanges. Some apps were exchanging tokens more than others, for example our loopback v3 app which exchanged tokens for each cloudant database configured with loopback however there was room for improvement in all apps as each kubernetes pod would request its own token. Approach used in this PR is below

## Approach

<!--
Be brief: which component(s) of the code base does the fix focus on.

A place to note whether the part of the code base that is being worked is
particularly sensitive.
-->
In order to prevent unnecessary IAM api token exchanges here we provide support for a cache object requiring two methods: get(key) and set(key, value, ttl) where ttl is the time to live. We also provide support for another parameter `cacheOffsetInSecs` which subtracts from the ttl to store in the cache so that we don't cut it too close to the expiry time. The cache should not return the token if the token is expired and instead allow the library to retrieve a new access token from IAM. The get and set API methods should return promises.

## Schema & API Changes

<!--
EITHER:

- "No change"

OR

For public API (as opposed to internal) changes

- "Fixing bug in API, will change x in such-and-such way"
-->
Two new config parameters are now supported in the `iamauth` plugin. Namely `cache` and `cacheOffsetInSecs` (their role is described above)

## Security and Privacy

<!--
EITHER:

- "No change"

OR

"Making changes in e.g. auth|https|encryption|io
need to be careful about..."

-->
The auth token received from IAM is now stored in a cache on the user side. This creates more responsibility for the library client to ensure the token is not compromised or leaked.

## Testing

<!--
EITHER:

- Added new tests:
    - test x
    - test y
    - test z

OR

- Modified existing tests because ...

OR

- N/A build or packaging only changes

OR

In exceptional circumstances there may be a good reason we can't add automated
tests, for example if a specific device is required to reproduce a problem.

- No new tests because...
-->
* Added new test `supports an IAM token cache` in `test/plugins/iamauth.js`

## Monitoring and Logging
<!--
EITHER:

- "No change"

OR

- "Added new log line X..."
-->
* Added new log line on line 42 of `lib/tokens/IAMTokenManager.js` to log when we are using a cached token.
