### PR TITLE
Fix constant token renewal in the absence of a cookie Max-Age

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+# Unreleased
+- [FIXED] Stopped constant token auto renewal in the absence of a cookie
+  header Max-Age
+
 # 4.2.4 (2020-03-02)
 - [FIXED] Pinned Nano to version 8.1 to resolve issue with extending upstream
   TypeScript changes in Nano version 8.2.0.

--- a/lib/tokens/TokenManager.js
+++ b/lib/tokens/TokenManager.js
@@ -35,7 +35,7 @@ class TokenManager {
       let maxAgeSecs = cookie.parse(response.headers['set-cookie'][0])['Max-Age'] || defaultMaxAgeSecs;
       let delayMSecs = maxAgeSecs / 2 * 1000;
       debug(`Renewing token in ${delayMSecs} milliseconds.`);
-      setTimeout(this._autoRenew.bind(this), delayMSecs).unref();
+      setTimeout(this._autoRenew.bind(this, defaultMaxAgeSecs), delayMSecs).unref();
     }).catch((error) => {
       debug(`Failed to auto renew token - ${error}. Retrying in 60 seconds.`);
       setTimeout(this._autoRenew.bind(this), 60000).unref();

--- a/test/tokens/TokenManager.js
+++ b/test/tokens/TokenManager.js
@@ -23,18 +23,27 @@ class TokenManagerRenewSuccess extends TokenManager {
   constructor() {
     super();
     this._getTokenCallCount = 0;
+    this._cookieHeader = 'Max-Age=1';
   }
 
   _getToken(callback) {
     this._getTokenCallCount += 1;
     setTimeout(() => {
-      callback(null, { headers: { 'set-cookie': [ 'Max-Age=1' ] } });
+      callback(null, { headers: { 'set-cookie': [ this._cookieHeader ] } });
     }, 100);
   }
 
   // mock successful token renewal
   get getTokenCallCount() {
     return this._getTokenCallCount;
+  }
+
+  get cookieHeader() {
+    return this._cookieHeader;
+  }
+
+  set cookieHeader(cookieHeader) {
+    this._cookieHeader = cookieHeader;
   }
 }
 
@@ -86,6 +95,17 @@ describe('Token Manger', (done) => {
     setTimeout(() => {
       // one renew every 0.5 seconds
       assert.equal(t.getTokenCallCount, 4);
+      done();
+    }, 2000);
+  });
+
+  it('correctly auto renews token in the absence of a cookie Max-Age', (done) => {
+    let t = new TokenManagerRenewSuccess();
+    t.cookieHeader = '';
+    t.startAutoRenew(2);
+    setTimeout(() => {
+      // one renew every 1 seconds
+      assert.equal(t.getTokenCallCount, 2);
       done();
     }, 2000);
   });


### PR DESCRIPTION
<!--
Thanks for your hard work, please ensure all items are complete before opening.
-->
## Checklist

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)
- [x] Added tests for code changes _or_ test/build only changes
- [x] Updated the change log file (`CHANGES.md`|`CHANGELOG.md`) _or_ test/build only changes
- [x] Completed the PR template below:

## Description
The TokenManager supports auto renewal of tokens. It uses the Max-Age field of the cookie header or a default value to schedule a callback for the renewal.

Fixes #426

<!--
Provide a short description; saving the detail for the `Approach` section

Also EITHER:
Link to issue this PR is resolving, use the Fixes #nnn form so that the
issue closes automatically when the PR merges e.g.:

Fixes #23

OR

For PRs without an associated issue and/or test/build issues

### 1. Steps to reproduce and the simplest code sample possible to demonstrate the issue
### 2. What you expected to happen
### 3. What actually happened
-->

## Approach

<!--
Be brief: which component(s) of the code base does the fix focus on.

A place to note whether the part of the code base that is being worked is
particularly sensitive.
-->

The problem is that the default value is only used for the first renewal. For subsequent renewals the default is undefined so the renewal is scheduled instantly unless a Max-Age field is found in the header:

```
  _autoRenew(defaultMaxAgeSecs) {
    debug('Auto renewing token now...');
    this._renew().then((response) => {
      let maxAgeSecs = cookie.parse(response.headers['set-cookie'][0])['Max-Age'] || defaultMaxAgeSecs;
      let delayMSecs = maxAgeSecs / 2 * 1000;
      debug(`Renewing token in ${delayMSecs} milliseconds.`);
      setTimeout(this._autoRenew.bind(this), delayMSecs).unref(); <-- defaultMaxAgeSecs not passed on
    }).catch((error) => {
      debug(`Failed to auto renew token - ${error}. Retrying in 60 seconds.`);
      setTimeout(this._autoRenew.bind(this), 60000).unref();
    });
  }
```

The fix is to pass the `defaultMaxAgeSecs` on to the setTimeout handler.

## Schema & API Changes
- "No change"
<!--
EITHER:

- "No change"

OR

For public API (as opposed to internal) changes

- "Fixing bug in API, will change x in such-and-such way"
-->

## Security and Privacy
- "No change"
<!--
EITHER:

- "No change"

OR

"Making changes in e.g. auth|https|encryption|io
need to be careful about..."

-->

## Testing
Added new test `correctly auto renews token in the absence of a cookie Max-Age` in `test/tokens/TokenManager.js`
<!--
EITHER:

- Added new tests:
    - test x
    - test y
    - test z

OR

- Modified existing tests because ...

OR

- N/A build or packaging only changes

OR

In exceptional circumstances there may be a good reason we can't add automated
tests, for example if a specific device is required to reproduce a problem.

- No new tests because...
-->

## Monitoring and Logging
- "No change"
<!--
EITHER:

- "No change"

OR

- "Added new log line X..."
-->
