### PR TITLE
Change timeout handling in TokenManager

### DIFF
--- a/lib/tokens/TokenManager.js
+++ b/lib/tokens/TokenManager.js
@@ -27,18 +27,20 @@ class TokenManager {
     this._isTokenRenewing = false;
 
     this._tokenExchangeEE = new EventEmitter().setMaxListeners(Infinity);
+    this._renewTimeout = {};
   }
 
   _autoRenew(defaultMaxAgeSecs) {
     debug('Auto renewing token now...');
+    clearTimeout(this._renewTimeout);
     this._renew().then((response) => {
       let maxAgeSecs = cookie.parse(response.headers['set-cookie'][0])['Max-Age'] || defaultMaxAgeSecs;
       let delayMSecs = maxAgeSecs / 2 * 1000;
       debug(`Renewing token in ${delayMSecs} milliseconds.`);
-      setTimeout(this._autoRenew.bind(this, defaultMaxAgeSecs), delayMSecs).unref();
+      this._renewTimeout = setTimeout(this._autoRenew.bind(this, defaultMaxAgeSecs), delayMSecs);
     }).catch((error) => {
       debug(`Failed to auto renew token - ${error}. Retrying in 60 seconds.`);
-      setTimeout(this._autoRenew.bind(this), 60000).unref();
+      this._renewTimeout = setTimeout(this._autoRenew.bind(this), 60000);
     });
   }
 

--- a/test/client.js
+++ b/test/client.js
@@ -121,11 +121,11 @@ describe('CloudantClient', function() {
         .reply(200, { ok: true }, MOCK_SET_COOKIE_HEADER)
         .get(DBNAME)
         .reply(201, {ok: true});
-      
+
       var cloudantClient = new Client({ creds: { outUrl: SERVER_WITH_CREDS } });
       assert.equal(cloudantClient._plugins.length, 1);
       assert.equal(cloudantClient._plugins[0].id, 'cookieauth');
-      
+
       var req = {
         url: SERVER + DBNAME,
         method: 'GET'
@@ -133,8 +133,8 @@ describe('CloudantClient', function() {
       cloudantClient.request(req, function(err, resp) {
         assert.equal(err, null);
         assert.equal(resp.statusCode, 201);
-        mocks.done();
         clearTimeout(cloudantClient._plugins[0]._tokenManager._renewTimeout);
+        mocks.done();
         done();
       });
     });
@@ -175,6 +175,12 @@ describe('CloudantClient', function() {
     });
 
     it('allows an array of plugins to be added via "plugins" options', function() {
+      var mocks = nock(SERVER)
+        .post('/_session')
+        .reply(200, { ok: true }, MOCK_SET_COOKIE_HEADER)
+        .get(DBNAME)
+        .reply(201, {ok: true});
+
       var cloudantClient = new Client({ creds: { outUrl: SERVER_WITH_CREDS },
         plugins: [
           'retry', // plugin 1
@@ -183,6 +189,19 @@ describe('CloudantClient', function() {
           'base' // ignored
         ]
       });
+
+      var req = {
+        url: SERVER + DBNAME,
+        method: 'GET'
+      };
+      cloudantClient.request(req, function(err, resp) {
+        assert.equal(err, null);
+        assert.equal(resp.statusCode, 201);
+        clearTimeout(cloudantClient._plugins[1]._tokenManager._renewTimeout);
+        mocks.done();
+        done();
+      });
+
       assert.equal(cloudantClient._plugins.length, 2);
     });
 

--- a/test/client.js
+++ b/test/client.js
@@ -174,7 +174,7 @@ describe('CloudantClient', function() {
       assert.equal(cloudantClient._plugins.length, 1);
     });
 
-    it('allows an array of plugins to be added via "plugins" options', function() {
+    it('allows an array of plugins to be added via "plugins" options', function(done) {
       var mocks = nock(SERVER)
         .post('/_session')
         .reply(200, { ok: true }, MOCK_SET_COOKIE_HEADER)

--- a/test/tokens/TokenManager.js
+++ b/test/tokens/TokenManager.js
@@ -95,6 +95,7 @@ describe('Token Manger', (done) => {
     setTimeout(() => {
       // one renew every 0.5 seconds
       assert.equal(t.getTokenCallCount, 4);
+      clearTimeout(t._renewTimeout);
       done();
     }, 2000);
   });
@@ -106,6 +107,7 @@ describe('Token Manger', (done) => {
     setTimeout(() => {
       // one renew every 1 seconds
       assert.equal(t.getTokenCallCount, 2);
+      clearTimeout(t._renewTimeout);
       done();
     }, 2000);
   });


### PR DESCRIPTION
<!--
Thanks for your hard work, please ensure all items are complete before opening.
-->
## Checklist

- [ ] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)
- [ ] Added tests for code changes _or_ test/build only changes
- [ ] Updated the change log file (`CHANGES.md`|`CHANGELOG.md`) _or_ test/build only changes
- [ ] Completed the PR template below:

## Description
<!--
Provide a short description; saving the detail for the `Approach` section

Also EITHER:
Link to issue this PR is resolving, use the Fixes #nnn form so that the
issue closes automatically when the PR merges e.g.:

Fixes #23

OR

For PRs without an associated issue and/or test/build issues

### 1. Steps to reproduce and the simplest code sample possible to demonstrate the issue
### 2. What you expected to happen
### 3. What actually happened
-->

According to the snapshot created by Eric, clearly can be seen there is a `setTimeout` that binds data to the native context.

> Native objects are everything else which is not in the JavaScript heap.

![Screenshot 2021-04-01 at 15 06 45](https://user-images.githubusercontent.com/26717393/113298218-e1f04a80-92fb-11eb-969b-1506dc75d428.png)

This code part refers to this:
```javascript
setTimeout(this._autoRenew.bind(this, defaultMaxAgeSecs), delayMSecs).unref()
```

Here is small code example that produce the same memory trace:
```javascript
var heapdump = require('heapdump');

function sleep(seconds){
    var waitUntil = new Date().getTime() + seconds*1000;
    while(new Date().getTime() < waitUntil) true;
}

function print() {
    console.log("Hello")
}

setTimeout(print, 10).unref();

sleep(2)

heapdump.writeSnapshot('./timeout-unref.heapsnapshot');
```

This produce the same memory trace:
![Screenshot 2021-04-01 at 15 35 15](https://user-images.githubusercontent.com/26717393/113301955-dd2d9580-92ff-11eb-935e-81d8614a39c7.png)

## Approach

<!--
Be brief: which component(s) of the code base does the fix focus on.

A place to note whether the part of the code base that is being worked is
particularly sensitive.
-->

Extending the sample code with a timer clear looks like this:

```javascript
var heapdump = require('heapdump');

function sleep(seconds){
    var waitUntil = new Date().getTime() + seconds*1000;
    while(new Date().getTime() < waitUntil) true;
}

function print() {
    console.log("Hello")
}

myTimer = setTimeout(print, 10);

sleep(1)

clearTimeout(myTimer)
myTimer = setTimeout(print, 10);

sleep(1)

clearTimeout(myTimer)

heapdump.writeSnapshot('./timeout-var.heapsnapshot');
```

And this code memory trace looks this way:
![Screenshot 2021-04-01 at 15 52 43](https://user-images.githubusercontent.com/26717393/113304475-5b8b3700-9302-11eb-80da-f626b481aed4.png)

This means that the referenced object will be placed into the `global` not into the `system/context` scope.

Hopefully this change will allow for the native objects to get cleared by GC.

## Schema & API Changes

<!--
EITHER:

- "No change"

OR

For public API (as opposed to internal) changes

- "Fixing bug in API, will change x in such-and-such way"
-->

## Security and Privacy

<!--
EITHER:

- "No change"

OR

"Making changes in e.g. auth|https|encryption|io
need to be careful about..."

-->

## Testing

Travis has some pending problem, but do not know why.

<!--
EITHER:

- Added new tests:
    - test x
    - test y
    - test z

OR

- Modified existing tests because ...

OR

- N/A build or packaging only changes

OR

In exceptional circumstances there may be a good reason we can't add automated
tests, for example if a specific device is required to reproduce a problem.

- No new tests because...
-->

## Monitoring and Logging
<!--
EITHER:

- "No change"

OR

- "Added new log line X..."
-->
