### PR TITLE
Change event emitter handling.

### DIFF
--- a/lib/tokens/TokenManager.js
+++ b/lib/tokens/TokenManager.js
@@ -26,19 +26,22 @@ class TokenManager {
     this._attemptTokenRenewal = true;
     this._isTokenRenewing = false;
 
-    this._tokenExchangeEE = new EventEmitter().setMaxListeners(Infinity);
+    this._tokenExchangeEE = {};
+    this._renewTimeout = {};
   }
 
   _autoRenew(defaultMaxAgeSecs) {
     debug('Auto renewing token now...');
+    this._tokenExchangeEE = {}
+    clearTimeout(this._renewTimeout);
     this._renew().then((response) => {
       let maxAgeSecs = cookie.parse(response.headers['set-cookie'][0])['Max-Age'] || defaultMaxAgeSecs;
       let delayMSecs = maxAgeSecs / 2 * 1000;
       debug(`Renewing token in ${delayMSecs} milliseconds.`);
-      setTimeout(this._autoRenew.bind(this, defaultMaxAgeSecs), delayMSecs).unref();
+      this._renewTimeout = setTimeout(this._autoRenew.bind(this, defaultMaxAgeSecs), delayMSecs);
     }).catch((error) => {
       debug(`Failed to auto renew token - ${error}. Retrying in 60 seconds.`);
-      setTimeout(this._autoRenew.bind(this), 60000).unref();
+      this._renewTimeout = setTimeout(this._autoRenew.bind(this), 60000);
     });
   }
 
@@ -51,7 +54,7 @@ class TokenManager {
   _renew() {
     if (!this._isTokenRenewing) {
       this._isTokenRenewing = true;
-      this._tokenExchangeEE.removeAllListeners();
+      this._tokenExchangeEE = new EventEmitter().setMaxListeners(Infinity)
       debug('Starting token renewal.');
       this._getToken((error, response) => {
         if (error) {

--- a/lib/tokens/TokenManager.js
+++ b/lib/tokens/TokenManager.js
@@ -32,7 +32,7 @@ class TokenManager {
 
   _autoRenew(defaultMaxAgeSecs) {
     debug('Auto renewing token now...');
-    this._tokenExchangeEE = {}
+    this._tokenExchangeEE = {};
     clearTimeout(this._renewTimeout);
     this._renew().then((response) => {
       let maxAgeSecs = cookie.parse(response.headers['set-cookie'][0])['Max-Age'] || defaultMaxAgeSecs;
@@ -54,7 +54,7 @@ class TokenManager {
   _renew() {
     if (!this._isTokenRenewing) {
       this._isTokenRenewing = true;
-      this._tokenExchangeEE = new EventEmitter().setMaxListeners(Infinity)
+      this._tokenExchangeEE = new EventEmitter().setMaxListeners(Infinity);
       debug('Starting token renewal.');
       this._getToken((error, response) => {
         if (error) {


### PR DESCRIPTION
<!--
Thanks for your hard work, please ensure all items are complete before opening.
-->
## Checklist

- [ ] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)
- [ ] Added tests for code changes _or_ test/build only changes
- [ ] Updated the change log file (`CHANGES.md`|`CHANGELOG.md`) _or_ test/build only changes
- [ ] Completed the PR template below:

## Description

Directs the memory leak problem.

<!--
Provide a short description; saving the detail for the `Approach` section

Also EITHER:
Link to issue this PR is resolving, use the Fixes #nnn form so that the
issue closes automatically when the PR merges e.g.:

Fixes #23

OR

For PRs without an associated issue and/or test/build issues

### 1. Steps to reproduce and the simplest code sample possible to demonstrate the issue
### 2. What you expected to happen
### 3. What actually happened
-->

## Approach
In all of the snapshot the global event emitter also keeps the TokenManager object in the memory. 
This change clears its content and its events.

![Screenshot 2021-05-07 at 12 38 09](https://user-images.githubusercontent.com/26717393/117437885-1d9cb680-af31-11eb-87ae-2283264c9b52.png)


<!--
Be brief: which component(s) of the code base does the fix focus on.

A place to note whether the part of the code base that is being worked is
particularly sensitive.
-->

## Schema & API Changes

<!--
EITHER:

- "No change"

OR

For public API (as opposed to internal) changes

- "Fixing bug in API, will change x in such-and-such way"
-->

## Security and Privacy

<!--
EITHER:

- "No change"

OR

"Making changes in e.g. auth|https|encryption|io
need to be careful about..."

-->

## Testing

<!--
EITHER:

- Added new tests:
    - test x
    - test y
    - test z

OR

- Modified existing tests because ...

OR

- N/A build or packaging only changes

OR

In exceptional circumstances there may be a good reason we can't add automated
tests, for example if a specific device is required to reproduce a problem.

- No new tests because...
-->

## Monitoring and Logging
<!--
EITHER:

- "No change"

OR

- "Added new log line X..."
-->
