### PR TITLE
Prepare 4.4.0 release

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,4 @@
-# Unreleased
+# 4.4.0 (2021-06-18)
 - [FIXED] Parsing of max-age from Set-Cookie headers.
 - [FIXED] Double callback if plugin errors when updating state.
 - [NOTE] Updated engines to remove EOL Node.js versions (minimum is now Node.js 12).

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "type": "git",
     "url": "git@github.com:cloudant/nodejs-cloudant.git"
   },
-  "version": "4.3.2-SNAPSHOT",
+  "version": "4.4.0",
   "author": {
     "name": "IBM Cloudant",
     "email": "support@cloudant.com"


### PR DESCRIPTION
# Proposed 4.4.0 release

Not yet complete. We need more changes first.
## Changes

### 4.4.0 (2021-06-18)
- [FIXED] Parsing of max-age from Set-Cookie headers.
- [FIXED] Double callback if plugin errors when updating state.
- [NOTE] Updated engines to remove EOL Node.js versions (minimum is now Node.js 12).

## Checklist

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)
- [x] Added tests for code changes _or_ test/build only changes
- [x] Updated the change log file (`CHANGES.md`|`CHANGELOG.md`) _or_ test/build only changes
- [x] Completed the PR template below: