### PR TITLE
456 retry timeout hang

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,6 @@
 # UNRELEASED
+- [FIXED] Hang caused by plugins (i.e. retry plugin) preventing callback execution
+  by attempting to retry on errors received after starting to return the response body.
 - [DEPRECATED] This library is now deprecated and will be EOL on Dec 31 2021.
 
 # 4.4.0 (2021-06-18)

--- a/README.md
+++ b/README.md
@@ -511,7 +511,10 @@ var cloudant = Cloudant({ url: myurl, maxAttempt: 5, plugins: [ { iamauth: { iam
     - `retryErrors`
 
       Automatically retry a request on error (e.g. connection reset errors)
-      _(default: true)_.
+      _(default: true)_. Note that this will only retry errors encountered
+      _before_ the library starts to read response body data. After that point
+      any errors (e.g. socket timeout reading from the server) will be returned
+      to the caller (via callback or emitted `error` depending on the usage). 
 
     - `retryInitialDelayMsecs`
 

--- a/lib/clientutils.js
+++ b/lib/clientutils.js
@@ -120,6 +120,7 @@ var processState = function(r, callback) {
   }
 
   // [5] => Return response to awaiting client.
+  r.state.final = true; // flags that we are terminating the loop
   setImmediate(callback, new Error('No retry requested')); // no retry
 };
 
@@ -157,7 +158,7 @@ var wrapCallback = function(r, done) {
       if (error) {
         runHooks('onError', r, error, function() {
           processState(r, function(stop) {
-            if (stop && !stop.skipClientCallback) {
+            if ((stop && !stop.skipClientCallback) || r.state.final) {
               r.clientCallback(error, response, body);
             }
             done(stop);

--- a/plugins/retry.js
+++ b/plugins/retry.js
@@ -14,7 +14,7 @@
 'use strict';
 
 const BasePlugin = require('./base.js');
-
+const debug = require('debug')('cloudant:plugins:retry');
 /**
  * Retry plugin.
  */
@@ -38,24 +38,28 @@ class RetryPlugin extends BasePlugin {
 
   onResponse(state, response, callback) {
     if (this._cfg.retryStatusCodes.indexOf(response.statusCode) !== -1) {
+      debug(`Received status code ${response.statusCode}; setting retry state.`);
       state.retry = true;
       if (state.attempt === 1) {
         state.retryDelayMsecs = this._cfg.retryInitialDelayMsecs;
       } else {
         state.retryDelayMsecs *= this._cfg.retryDelayMultiplier;
       }
+      debug(`Asking for retry after ${state.retryDelayMsecs}`);
     }
     callback(state);
   }
 
   onError(state, error, callback) {
     if (this._cfg.retryErrors) {
+      debug(`Received error ${error.code} ${error.message}; setting retry state.`);
       state.retry = true;
       if (state.attempt === 1) {
         state.retryDelayMsecs = this._cfg.retryInitialDelayMsecs;
       } else {
         state.retryDelayMsecs *= this._cfg.retryDelayMultiplier;
       }
+      debug(`Asking for retry after ${state.retryDelayMsecs}`);
     }
     callback(state);
   }


### PR DESCRIPTION
<!--
Thanks for your hard work, please ensure all items are complete before opening.
-->
## Checklist

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)
- [x] Added tests for code changes _or_ test/build only changes
- [x] Updated the change log file (`CHANGES.md`|`CHANGELOG.md`) _or_ test/build only changes
- [x] Completed the PR template below:

## Description

Ensure callback gets called for errors after response is already being processed.

Fixes #456 

## Approach

* Add a flag when the execution loop is stopped.
* Force the client callback when processing a callback `error` if the flag is set.
* Update documentation to clarify behaviour of retry plugin.

It is worth noting the current behaviour on an error encountered during response processing when using the retry plugin is:
* The retry plugin asks for a retry, but it does not get executed.
* Callback style -> hangs with the callback not called
* Listener style -> an event is emitted for the error (between the `response` and `end` events)

This change retains the current behaviour except for the hang where the callback isn't called. It is not possible to allow retries once the response is already processing because it will change the events in the listener style usage (and multiple response or data events will be unexpected and difficult to manage).

## Schema & API Changes

- No change
- Added documentation clarification for expected behaviour of retry plugin.

## Security and Privacy

- "No change"

## Testing

- Added new tests:
    - `does not retry in response data phase` for `callback only` `listener only` and `callback and listener` scenarios of retry plugin tests

The tests cannot use `nock` because it does not trigger the timeouts, so they use their own mock server.

## Monitoring and Logging

- Added debug statements to retry plugin.
