### PR TITLE
Prepare 4.4.1 release

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,4 @@
-# UNRELEASED
+# 4.4.1 (2021-08-02)
 - [FIXED] Hang caused by plugins (i.e. retry plugin) preventing callback execution
   by attempting to retry on errors received after starting to return the response body.
 - [DEPRECATED] This library is now deprecated and will be EOL on Dec 31 2021.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloudant/cloudant",
-  "version": "4.4.1-SNAPSHOT",
+  "version": "4.4.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "type": "git",
     "url": "git@github.com:cloudant/nodejs-cloudant.git"
   },
-  "version": "4.4.1-SNAPSHOT",
+  "version": "4.4.1",
   "author": {
     "name": "IBM Cloudant",
     "email": "support@cloudant.com"


### PR DESCRIPTION
# Proposed 4.4.1 release

# Changes

# 4.4.1 (2021-08-02)
- [FIXED] Hang caused by plugins (i.e. retry plugin) preventing callback execution
  by attempting to retry on errors received after starting to return the response body.
- [DEPRECATED] This library is now deprecated and will be EOL on Dec 31 2021.