### PR TITLE
Cookie persistence workaround

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+# Unreleased
+- [FIXED] Issue where new session cookies from pre-emptive renewal would not persist beyond the original session
+  lifetime.
+
 # 4.5.0 (2021-08-26)
 - [IMPROVED] - Document IDs and attachment names are now rejected if they could cause an unexpected
   Cloudant request. We have seen that some applications pass unsantized document IDs to SDK functions

--- a/lib/tokens/TokenManager.js
+++ b/lib/tokens/TokenManager.js
@@ -27,6 +27,50 @@ class TokenManager {
     this._isTokenRenewing = false;
 
     this._tokenExchangeEE = new EventEmitter().setMaxListeners(Infinity);
+
+    // START monkey patch for https://github.com/salesforce/tough-cookie/issues/154
+    // Use the tough-cookie CookieJar from the RequestJar
+    const cookieJar = this._jar ? this._jar._jar : false;
+    // Check if we've already patched the jar
+    if (cookieJar && !cookieJar.cloudantPatch) {
+      // Set the patching flag
+      cookieJar.cloudantPatch = true;
+      // Replace the store's updateCookie function with one that applies a patch to newCookie
+      const originalUpdateCookieFn = cookieJar.store.updateCookie;
+      cookieJar.store.updateCookie = function(oldCookie, newCookie, cb) {
+        // Add current time as an update timestamp to the newCookie
+        newCookie.cloudantPatchUpdateTime = new Date();
+        // Replace the cookie's expiryTime function with one that uses cloudantPatchUpdateTime
+        // in place of creation time to check the expiry.
+        const originalExpiryTimeFn = newCookie.expiryTime;
+        newCookie.expiryTime = function(now) {
+          // The original expiryTime check is relative to a time in this order:
+          // 1. supplied now argument
+          // 2. this.creation (original cookie creation time)
+          // 3. current time
+          // This patch replaces 2 with an expiry check relative to the cloudantPatchUpdateTime if set instead of
+          // the creation time by passing it as the now argument.
+          return originalExpiryTimeFn.call(
+            newCookie,
+            newCookie.cloudantPatchUpdateTime || now
+          );
+        };
+        // Finally delegate back to the original update function or the fallback put (which is set by Cookie
+        // when an update function is not present on the store). Since we always set an update function for our
+        // patch we need to also provide that fallback.
+        if (originalUpdateCookieFn) {
+          originalUpdateCookieFn.call(
+            cookieJar.store,
+            oldCookie,
+            newCookie,
+            cb
+          );
+        } else {
+          cookieJar.store.putCookie(newCookie, cb);
+        }
+      };
+    }
+    // END cookie jar monkey patch
   }
 
   _autoRenew(defaultMaxAgeSecs) {


### PR DESCRIPTION
## Checklist

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)
- [x] Added tests for code changes _or_ test/build only changes
- [x] Updated the change log file (`CHANGES.md`|`CHANGELOG.md`) _or_ test/build only changes
- [x] Completed the PR template below:

## Description

Patch tough-cookie bug in TokenManager

Fixes #463

## Approach

Patch the cookie jar used in the `TokenManager` with the workaround for sliding updates in `tough-cookie`. This is mostly the same patch we used in `cloudant-node-sdk` just with a slight change to the initial `_jar` checks to suit the `request` module.

## Schema & API Changes

- "No change"

## Security and Privacy

- "No change"

## Testing

- Added a new test to validate a renewed cookie is applied after the original session lifetime expired.

## Monitoring and Logging

- "No change"
