### PR TITLE
Prepare 4.5.1 release

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,4 @@
-# Unreleased
+# 4.5.1 (2021-09-16)
 - [FIXED] Issue where new session cookies from pre-emptive renewal would not persist beyond the original session
   lifetime.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloudant/cloudant",
-  "version": "4.5.1-SNAPSHOT",
+  "version": "4.5.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "type": "git",
     "url": "git@github.com:cloudant/nodejs-cloudant.git"
   },
-  "version": "4.5.1-SNAPSHOT",
+  "version": "4.5.1",
   "author": {
     "name": "IBM Cloudant",
     "email": "support@cloudant.com"


### PR DESCRIPTION
# Proposed 4.5.1 (2021-09-16) release

# Changes
- [FIXED] Issue where new session cookies from pre-emptive renewal would not persist beyond the original session lifetime.