### PR TITLE
Improve migration guide

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -20,16 +20,17 @@ There are several ways to create a client connection in `cloudant-node-sdk`:
 1. Plugins are not supported, but several of the plugin features exist in the new library e.g. IAM, [automatic retries](https://github.com/IBM/ibm-cloud-sdk-common/#automatic-retries) for failed requests.
 1. Error handling is not transferable from `@cloudant/cloudant` to `@ibm-cloud/cloudant`. For more information go to the [Error handling section](https://cloud.ibm.com/apidocs/cloudant?code=node#error-handling) in our API docs.
 1. Custom HTTP client configurations in `@cloudant/cloudant` are not transferable to
-   `@ibm-cloud/cloudant`. For more information go to the [Configuring the HTTP client section]
-   (https://github.com/IBM/ibm-cloud-sdk-common/#configuring-the-http-client) in the IBM Cloud 
-   SDK Common README.
+   `@ibm-cloud/cloudant`. For more information go to the
+   [Configuring the HTTP client section](https://github.com/IBM/ibm-cloud-sdk-common/#configuring-the-http-client)
+   in the IBM Cloud SDK Common README.
 1. Authentication errors occur during service instantiation. For example, the code `const
    service = CloudantV1.newInstance({ serviceName: 'EXAMPLE' });` will fail with `` At least one
    of `iamProfileName` or `iamProfileId` must be specified. `` if required environment variables
    prefixed with `EXAMPLE` are not set.
 1. Server errors occur when running a request against the service. We suggest to
-   check server errors with [`getServerInformation`](https://cloud.ibm.com/apidocs/cloudant?
-   code=node#getserverinformation) which is the new alternative of `ping`.
+   check server errors with
+   [`getServerInformation`](https://cloud.ibm.com/apidocs/cloudant?code=node#getserverinformation)
+   which is the new alternative of `ping`.
 
 ## Request mapping
 Here's a list of the top 5 most frequently used `nodejs-cloudant` operations and the `cloudant-node-sdk` equivalent API operation documentation link:

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -14,7 +14,8 @@ There are several ways to create a client connection in `cloudant-node-sdk`:
 1. Fetching the database object first before performing additional operations is not required. For example, in the case of updating a document you would first call `getDocument` to fetch and then `putDocument` to update.
 1. Plugins are not supported, but several of the plugin features exist in the new library e.g. IAM, [automatic retries](https://github.com/IBM/ibm-cloud-sdk-common/#automatic-retries) for failed requests.
 1. Error handling is not transferable from `@cloudant/cloudant` to `@ibm-cloud/cloudant`. For more information go to the [Error handling section](https://cloud.ibm.com/apidocs/cloudant?code=node#error-handling) in our API docs.
-1. Custom HTTP client configurations in `@cloudant/cloudant` are not transferable to are not transferable to `@ibm-cloud/cloudant`. For more information go to the [Configuring the HTTP client section](https://github.com/IBM/ibm-cloud-sdk-common/#configuring-the-http-client) in the IBM Cloud SDK Common README.
+1. Custom HTTP client configurations in `@cloudant/cloudant` are not transferable to 
+   `@ibm-cloud/cloudant`. For more information go to the [Configuring the HTTP client section](https://github.com/IBM/ibm-cloud-sdk-common/#configuring-the-http-client) in the IBM Cloud SDK Common README.
 
 ## Request mapping
 Here's a list of the top 5 most frequently used `nodejs-cloudant` operations and the `cloudant-node-sdk` equivalent API operation documentation link:

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -20,7 +20,7 @@ There are several ways to create a client connection in `cloudant-node-sdk`:
     operation also became obsoleted.
 1. Plugins are not supported, but several of the plugin features exist in the new library e.g. IAM, [automatic retries](https://github.com/IBM/ibm-cloud-sdk-common/#automatic-retries) for failed requests.
 1. Error handling is not transferable from `@cloudant/cloudant` to `@ibm-cloud/cloudant`. For more information go to the [Error handling section](https://cloud.ibm.com/apidocs/cloudant?code=node#error-handling) in our API docs.
-1. Custom HTTP client configurations in `@cloudant/cloudant` are not transferable to
+1. Custom HTTP client configurations in `@cloudant/cloudant` can be set differently in
    `@ibm-cloud/cloudant`. For more information go to the
    [Configuring the HTTP client section](https://github.com/IBM/ibm-cloud-sdk-common/#configuring-the-http-client)
    in the IBM Cloud SDK Common README.

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -12,17 +12,19 @@ There are several ways to create a client connection in `cloudant-node-sdk`:
 ## Other differences
 1. Using the `dotenv` package to store credentials in a file is not recommended. See the [external file configuration section](https://github.com/IBM/cloudant-node-sdk#authentication-with-external-configuration) in our API docs for handling this feature in our new library.
 1.  In `cloudant-node-sdk` all operations are performed from the scope of the client instance and
-    not associated with any sub-scope like the database. There is no need to instantiate a 
-    database object to interact with documents - the database name is included as part of 
+    not associated with any sub-scope like the database. There is no need to instantiate a
+    database object to interact with documents - the database name is included as part of
     document operations. For example, in the case of updating a document you would first call
-    `getDocument` to fetch and then `putDocument` to update. As a result of which the `use` 
+    `getDocument` to fetch and then `putDocument` to update. As a result of which the `use`
     operation also became invalid.
 1. Plugins are not supported, but several of the plugin features exist in the new library e.g. IAM, [automatic retries](https://github.com/IBM/ibm-cloud-sdk-common/#automatic-retries) for failed requests.
 1. Error handling is not transferable from `@cloudant/cloudant` to `@ibm-cloud/cloudant`. For more information go to the [Error handling section](https://cloud.ibm.com/apidocs/cloudant?code=node#error-handling) in our API docs.
-1. Custom HTTP client configurations in `@cloudant/cloudant` are not transferable to 
-   `@ibm-cloud/cloudant`. For more information go to the [Configuring the HTTP client section](https://github.com/IBM/ibm-cloud-sdk-common/#configuring-the-http-client) in the IBM Cloud SDK Common README.
-1. Authentication errors turn out at the time of instantiation of a client, while errors 
-   with the server can be found during calling the first operation against it. We suggest to 
+1. Custom HTTP client configurations in `@cloudant/cloudant` are not transferable to
+   `@ibm-cloud/cloudant`. For more information go to the [Configuring the HTTP client section]
+   (https://github.com/IBM/ibm-cloud-sdk-common/#configuring-the-http-client) in the IBM Cloud 
+   SDK Common README.
+1. Authentication errors turn out at the time of instantiation of a client, while errors
+   with the server can be found during calling the first operation against it. We suggest to
    check server errors with [`getServerInformation`](https://cloud.ibm.com/apidocs/cloudant?
    code=node#getserverinformation) which is the new alternative of `ping`.
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -24,6 +24,8 @@ There are several ways to create a client connection in `cloudant-node-sdk`:
    `@ibm-cloud/cloudant`. For more information go to the
    [Configuring the HTTP client section](https://github.com/IBM/ibm-cloud-sdk-common/#configuring-the-http-client)
    in the IBM Cloud SDK Common README.
+   
+### Troubleshooting
 1. Authentication errors occur during service instantiation. For example, the code `const
    service = CloudantV1.newInstance({ serviceName: 'EXAMPLE' });` will fail with `` At least one
    of `iamProfileName` or `iamProfileId` must be specified. `` if required environment variables

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -15,8 +15,8 @@ There are several ways to create a client connection in `cloudant-node-sdk`:
     not associated with any sub-scope like the database. There is no need to instantiate a
     database object to interact with documents - the database name is included as part of
     document operations. For example, in the case of updating a document you would first call
-    `` getDocument({ db: `${dbName}`, docId:`${docId}`}) `` to fetch and then `` putDocument({ 
-    db: `${dbName}`, docId:`${docId}`}) `` to update. As a result of which the `use`
+    `getDocument({ db: dbName, docId: docId})` to fetch and then `putDocument({ 
+    db: dbName, docId: docId})` to update. As a result of which the `use`
     operation also became obsoleted.
 1. Plugins are not supported, but several of the plugin features exist in the new library e.g. IAM, [automatic retries](https://github.com/IBM/ibm-cloud-sdk-common/#automatic-retries) for failed requests.
 1. Error handling is not transferable from `@cloudant/cloudant` to `@ibm-cloud/cloudant`. For more information go to the [Error handling section](https://cloud.ibm.com/apidocs/cloudant?code=node#error-handling) in our API docs.

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -11,7 +11,12 @@ There are several ways to create a client connection in `cloudant-node-sdk`:
 
 ## Other differences
 1. Using the `dotenv` package to store credentials in a file is not recommended. See the [external file configuration section](https://github.com/IBM/cloudant-node-sdk#authentication-with-external-configuration) in our API docs for handling this feature in our new library.
-1. Fetching the database object first before performing additional operations is not required. For example, in the case of updating a document you would first call `getDocument` to fetch and then `putDocument` to update.
+1.  In `cloudant-node-sdk` all operations are performed from the scope of the client instance and
+    not associated with any sub-scope like the database. There is no need to instantiate a 
+    database object to interact with documents - the database name is included as part of 
+    document operations. For example, in the case of updating a document you would first call
+    `getDocument` to fetch and then `putDocument` to update. As a result of which the `use` 
+    operation also became invalid.
 1. Plugins are not supported, but several of the plugin features exist in the new library e.g. IAM, [automatic retries](https://github.com/IBM/ibm-cloud-sdk-common/#automatic-retries) for failed requests.
 1. Error handling is not transferable from `@cloudant/cloudant` to `@ibm-cloud/cloudant`. For more information go to the [Error handling section](https://cloud.ibm.com/apidocs/cloudant?code=node#error-handling) in our API docs.
 1. Custom HTTP client configurations in `@cloudant/cloudant` are not transferable to 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -23,8 +23,11 @@ There are several ways to create a client connection in `cloudant-node-sdk`:
    `@ibm-cloud/cloudant`. For more information go to the [Configuring the HTTP client section]
    (https://github.com/IBM/ibm-cloud-sdk-common/#configuring-the-http-client) in the IBM Cloud 
    SDK Common README.
-1. Authentication errors turn out at the time of instantiation of a client, while errors
-   with the server can be found during calling the first operation against it. We suggest to
+1. Authentication errors occur during service instantiation. For example, the code `const
+   service = CloudantV1.newInstance({ serviceName: 'EXAMPLE' });` will fail with `` At least one
+   of `iamProfileName` or `iamProfileId` must be specified. `` if required environment variables
+   prefixed with `EXAMPLE` are not set.
+1. Server errors occur when running a request against the service. We suggest to
    check server errors with [`getServerInformation`](https://cloud.ibm.com/apidocs/cloudant?
    code=node#getserverinformation) which is the new alternative of `ping`.
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -15,8 +15,9 @@ There are several ways to create a client connection in `cloudant-node-sdk`:
     not associated with any sub-scope like the database. There is no need to instantiate a
     database object to interact with documents - the database name is included as part of
     document operations. For example, in the case of updating a document you would first call
-    `getDocument` to fetch and then `putDocument` to update. As a result of which the `use`
-    operation also became invalid.
+    `` getDocument({ db: `${dbName}`, docId:`${docId}`}) `` to fetch and then `` putDocument({ 
+    db: `${dbName}`, docId:`${docId}`}) `` to update. As a result of which the `use`
+    operation also became obsoleted.
 1. Plugins are not supported, but several of the plugin features exist in the new library e.g. IAM, [automatic retries](https://github.com/IBM/ibm-cloud-sdk-common/#automatic-retries) for failed requests.
 1. Error handling is not transferable from `@cloudant/cloudant` to `@ibm-cloud/cloudant`. For more information go to the [Error handling section](https://cloud.ibm.com/apidocs/cloudant?code=node#error-handling) in our API docs.
 1. Custom HTTP client configurations in `@cloudant/cloudant` are not transferable to

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -21,6 +21,10 @@ There are several ways to create a client connection in `cloudant-node-sdk`:
 1. Error handling is not transferable from `@cloudant/cloudant` to `@ibm-cloud/cloudant`. For more information go to the [Error handling section](https://cloud.ibm.com/apidocs/cloudant?code=node#error-handling) in our API docs.
 1. Custom HTTP client configurations in `@cloudant/cloudant` are not transferable to 
    `@ibm-cloud/cloudant`. For more information go to the [Configuring the HTTP client section](https://github.com/IBM/ibm-cloud-sdk-common/#configuring-the-http-client) in the IBM Cloud SDK Common README.
+1. Authentication errors turn out at the time of instantiation of a client, while errors 
+   with the server can be found during calling the first operation against it. We suggest to 
+   check server errors with [`getServerInformation`](https://cloud.ibm.com/apidocs/cloudant?
+   code=node#getserverinformation) which is the new alternative of `ping`.
 
 ## Request mapping
 Here's a list of the top 5 most frequently used `nodejs-cloudant` operations and the `cloudant-node-sdk` equivalent API operation documentation link:


### PR DESCRIPTION
<!--
Thanks for your hard work, please ensure all items are complete before opening.
-->
## Checklist

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)
- [ ] Added tests for code changes _or_ test/build only changes
- [ ] Updated the change log file (`CHANGES.md`|`CHANGELOG.md`) _or_ test/build only changes
- [x] Completed the PR template below:

## Description
There have been some questions regarding migration lately. This PR tries to address them.

## Approach

I clarified some of the questionable topics in this change:
* why is `use` not available anymore in the new SDK
* where users should check the server errors and the authentication errors

I also fixed a sentence where `are not transferable to` was there twice.

My IDE lately breaks the lines automatically, I have not figured out how I can turn it off yet, but I think this is a great feature, and it helps the reviewers to read the long lines more effectively, so I kept these modifications.

## Schema & API Changes

- "No change"

## Security and Privacy

- "No change"


## Testing

- N/A

## Monitoring and Logging

- "No change"
